### PR TITLE
filter by length and taxonomy

### DIFF
--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -299,7 +299,11 @@ plugin.methods.register_function(
         'labels': 'One or more taxonomic labels to use for conditional '
                   'filtering. For example, use this option to set different '
                   'min/max filter settings for individual phyla. Must input '
-                  'the same number of labels as min_lens and/or max_lens.',
+                  'the same number of labels as min_lens and/or max_lens. If '
+                  'a sequence matches multiple taxonomic labels, this method '
+                  'will apply the most stringent threshold(s): the longest '
+                  'minimum length and/or the shortest maximum length that is '
+                  'associated with the matching labels.',
         'min_lens': 'Minimum length thresholds to use for filtering sequences '
                     'associated with each label. If any min_lens are '
                     'specified, must have the same number of min_lens as '
@@ -318,9 +322,12 @@ plugin.methods.register_function(
     description=(
         'Filter sequences by length. Can filter both globally by minimum '
         'and/or maximum length, and set individual threshold for individual '
-        'taxonomic groups (using the "labels" option). For global length-'
-        'based filtering without conditional taxonomic filtering, see '
-        'filter_seqs_globally.'),
+        'taxonomic groups (using the "labels" option). Note that filtering '
+        'can be performed for multiple taxonomic groups simultaneously, and '
+        'nested taxonomic filters can be applied (e.g., to apply a more '
+        'stringent filter for a particular genus, but a less stringent filter '
+        'for other members of the kingdom). For global length-based filtering '
+        'without conditional taxonomic filtering, see filter_seqs_globally.'),
 )
 
 
@@ -338,9 +345,7 @@ plugin.methods.register_function(
         **FILTER_PARAM_DESCRIPTIONS,
         'threads': 'Number of computation threads to use (1 to 256). The '
                    'number of threads should be lesser or equal to the number '
-                   'of available CPU cores. ONLY USED IF FILTERING BY '
-                   'global_min AND/OR global_max, this option is IGNORED if '
-                   'filtering based on taxonomic labels.'},
+                   'of available CPU cores.'},
     output_descriptions=FILTER_OUTPUT_DESCRIPTIONS,
     name='Filter sequences by length.',
     description=(


### PR DESCRIPTION
added two new methods:
1. filter_seqs_by_taxon allows length-based filtering conditionally by taxonomic label (with optional global length filtering options)
2. filter_seqs_globally wraps vsearch for quicker global length filtering

filter_seqs_globally is about 2X as fast as filter_seqs_by_taxon when only global filters are applied, without parallelization. I decided to make the vsearch wrapper because vsearch will be faster and support multithreading when you want to just apply a global filter fast. We should look into parallelizing filter_seqs_by_taxon in the future... but we should also look into expanding the functionality of filter_seqs_globally to include other vsearch filtering options (e.g., there is a maxN filter that would have these same advantages).

Both are pretty fast, though: here's a time comparison demonstrating relative runtime with a basic global filter:
```
time qiime rescript filter-seqs-by-taxon --i-sequences gg_13_8_otus/rep_set/88_otus.qza --o-filtered-seqs gg_13_8_otus/rep_set/88_otus-taxonomic-filter-test.qza --o-discarded-seqs gg_13_8_otus/rep_set/88_otus-taxonomic-discard-test.qza --p-labels Bacteria Archaea --p-max-lens 1400 1400 --i-taxonomy gg_13_8_otus/taxonomy/88_otu_taxonomy.qza
real	0m13.683s
user	0m12.276s
sys	0m0.970s


time qiime rescript filter-seqs-globally --i-sequences gg_13_8_otus/rep_set/88_otus.qza --o-filtered-seqs gg_13_8_otus/rep_set/88_otus-global-filter-test.qza --o-discarded-seqs gg_13_8_otus/rep_set/88_otus-global-discard-test.qza --p-global-max 1400
real	0m7.341s
user	0m6.432s
sys	0m0.737s


time qiime rescript filter-seqs-by-taxon --i-sequences gg_13_8_otus/rep_set/97_otus.qza --o-filtered-seqs gg_13_8_otus/rep_set/97_otus-taxonomic-filter-test.qza --o-discarded-seqs gg_13_8_otus/rep_set/97_otus-taxonomic-discard-test.qza --p-labels Bacteria Archaea --p-max-lens 1400 1400 --i-taxonomy gg_13_8_otus/taxonomy/97_otu_taxonomy.qza
real	1m31.122s
user	1m23.774s
sys	0m4.143s


time qiime rescript filter-seqs-globally --i-sequences gg_13_8_otus/rep_set/97_otus.qza --o-filtered-seqs gg_13_8_otus/rep_set/97_otus-global-filter-test.qza --o-discarded-seqs gg_13_8_otus/rep_set/97_otus-global-discard-test.qza --p-global-max 1400
real	0m33.659s
user	0m26.655s
sys	0m2.797s
```

And verifying that results are consistent between these methods for equivalent filtering settings:
```
>>> import qiime2 as q2, pandas as pd
>>> vd = q2.Artifact.load('gg_13_8_otus/rep_set/97_otus-global-discard-test.qza')
>>> vf = q2.Artifact.load('gg_13_8_otus/rep_set/97_otus-global-filter-test.qza')
>>> qd = q2.Artifact.load('gg_13_8_otus/rep_set/97_otus-taxonomic-discard-test.qza')
>>> qf = q2.Artifact.load('gg_13_8_otus/rep_set/97_otus-taxonomic-filter-test.qza')
>>> qd.view(pd.Series).index.symmetric_difference(vd.view(pd.Series).index)
Index([], dtype='object')
>>> qf.view(pd.Series).index.symmetric_difference(vf.view(pd.Series).index)
Index([], dtype='object')
```