### PR TITLE
enable labels in eval visualizations

### DIFF
--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -62,6 +62,13 @@ rank_handle_extra_note = (
     'Note that rank_handles are removed but not replaced; use the '
     'new_rank_handle parameter to replace the rank handles.')
 
+labels_description = (
+    'List of labels to use for labeling taxonomic results in the resulting '
+    'visualization. Taxonomies are labeled with labels in the order that each '
+    'is input. If there are fewer labels than taxonomies (or no labels), '
+    'unnamed taxonomies are labeled numerically in sequential order. Extra '
+    'labels are ignored.')
+
 
 plugin.pipelines.register_function(
     function=cross_validate,
@@ -112,7 +119,7 @@ plugin.pipelines.register_function(
     function=evaluate_classifications,
     inputs={'expected_taxonomies': List[FeatureData[Taxonomy]],
             'observed_taxonomies': List[FeatureData[Taxonomy]]},
-    parameters={},
+    parameters={'labels': List[Str]},
     outputs=[('evaluation', Visualization)],
     input_descriptions={
         'expected_taxonomies': 'True taxonomic labels for one more more sets '
@@ -120,7 +127,7 @@ plugin.pipelines.register_function(
         'observed_taxonomies': 'Predicted classifications of same sets of '
                                'features, input in same order as '
                                'expected_taxonomies.'},
-    parameter_descriptions={},
+    parameter_descriptions={'labels': labels_description},
     output_descriptions={
         'evaluation': 'Visualization of classification accuracy results.'},
     name=('Interactively evaluate taxonomic classification accuracy.'),
@@ -224,11 +231,13 @@ plugin.methods.register_function(
 plugin.pipelines.register_function(
     function=evaluate_taxonomy,
     inputs={'taxonomies': List[FeatureData[Taxonomy]]},
-    parameters={'rank_handle': Str},
+    parameters={'labels': List[Str],
+                'rank_handle': Str},
     outputs=[('taxonomy_stats', Visualization)],
     input_descriptions={
         'taxonomies': 'One or more taxonomies to evaluate.'},
     parameter_descriptions={
+        'labels': labels_description,
         'rank_handle': rank_handle_description,
     },
     name='Compute summary statistics on taxonomy artifact(s).',

--- a/rescript/tests/test_evaluate.py
+++ b/rescript/tests/test_evaluate.py
@@ -18,6 +18,33 @@ from rescript import evaluate
 import_data = qiime2.Artifact.import_data
 
 
+class TestEvaluateUtilities(TestPluginBase):
+    package = 'rescript.tests'
+
+    # test that warning is raised when there are fewer labels than Taxonomies
+    # and that missing labels are labeled numerically
+    def test_process_labels_warning(self):
+        labels = ['a', 'b']
+        # this function just looks at lists, not the actual contents type
+        dummy_taxonomies = [1, 2, 3, 4, 5]
+        with self.assertWarnsRegex(
+                UserWarning, "taxonomies and labels are different lengths"):
+            new_labels = evaluate._process_labels(labels, dummy_taxonomies)
+        self.assertEqual(new_labels, ['a', 'b', 3, 4, 5])
+
+    # test that _process_labels trims labels when too many are given
+    def test_process_labels_too_many_labels(self):
+        labels = ['a', 'b', 'c', 'd', 'e']
+        dummy_taxonomies = [1, 2, 3]
+        new_labels = evaluate._process_labels(labels, dummy_taxonomies)
+        self.assertEqual(new_labels, ['a', 'b', 'c'])
+
+    def test_process_labels_empty(self):
+        dummy_taxonomies = [1, 2, 3]
+        new_labels = evaluate._process_labels(None, dummy_taxonomies)
+        self.assertEqual(new_labels, [1, 2, 3])
+
+
 class TestEvaluateTaxonomy(TestPluginBase):
     package = 'rescript.tests'
 
@@ -29,7 +56,7 @@ class TestEvaluateTaxonomy(TestPluginBase):
 
     # this just tests that the pipeline runs, other tests test proper function
     def test_pipeline(self):
-        rescript.actions.evaluate_taxonomy([self.taxa], "")
+        rescript.actions.evaluate_taxonomy([self.taxa], ["name"], "")
 
     def test_taxonomic_depth(self):
         obs_depths = evaluate._taxonomic_depth(self.taxa.view(pd.Series), "")


### PR DESCRIPTION
the `evaluate-*` visualizations can now accept a list of labels as input... these are used to label the results of those data in the resulting visualization, like so (see the legend on the right):
![image](https://user-images.githubusercontent.com/1907564/83669270-213bf680-a586-11ea-8101-43e87c657ffa.png)

If fewer labels (or none) are given than the number of taxonomies, the remaining are labeled numerically in the order that they are input:
![image](https://user-images.githubusercontent.com/1907564/83669329-3c0e6b00-a586-11ea-822e-6b7297f81edc.png)
