### PR TITLE
generalize doi etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RESCRIPt
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3891932.svg)](https://doi.org/10.5281/zenodo.3891932)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3891931.svg)](https://doi.org/10.5281/zenodo.3891931)
  ![lint-build-test](https://github.com/bokulich-lab/RESCRIPt/workflows/lint-build-test/badge.svg)
 
 REference Sequence annotation and CuRatIon Pipeline
@@ -20,7 +20,7 @@ conda create -y -n rescript
 conda activate rescript
 conda install \
   -c conda-forge -c bioconda -c qiime2 -c defaults \
-  qiime2 q2cli q2templates q2-types q2-longitudinal q2-feature-classifier
+  qiime2 q2cli q2templates q2-types q2-longitudinal q2-feature-classifier "pandas>=0.25.3"
 ```
 
 Finally install from source:
@@ -29,11 +29,17 @@ Finally install from source:
 pip install git+https://github.com/bokulich-lab/RESCRIPt.git
 ```
 
+To view a help menu for using rescript via the QIIME 2 CLI:
+```
+qiime dev refresh-cache
+qiime --help
+```
+
 ## Citation
 
 A proper software announcement is forthcoming. In the meantime, if you use RESCRIPt in your research, please cite the Zenodo record:
 
-Nicholas Bokulich, Mike Robeson, & Matthew Dillon. (2020, June 12). bokulich-lab/RESCRIPt: 2020.6.0 (Version 2020.6.0). Zenodo. http://doi.org/10.5281/zenodo.3891932
+Nicholas Bokulich, Mike Robeson, & Matthew Dillon. bokulich-lab/RESCRIPt. Zenodo. http://doi.org/10.5281/zenodo.3891931
 
 ## License
 

--- a/rescript/cross_validate.py
+++ b/rescript/cross_validate.py
@@ -21,7 +21,6 @@ from .evaluate import _taxonomic_depth, _process_labels
 def evaluate_fit_classifier(ctx,
                             sequences,
                             taxonomy,
-                            random_state=0,
                             reads_per_batch=0,
                             n_jobs=1,
                             confidence=0.7):
@@ -29,7 +28,6 @@ def evaluate_fit_classifier(ctx,
     taxonomy: pd.Series of taxonomy labels
     sequences: pd.Series of sequences
     k: number of kfold cv splits to perform.
-    random_state: random state for cv.
     '''
     # Validate inputs
     start = timeit.default_timer()

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -91,7 +91,6 @@ plugin.pipelines.register_function(
     inputs={'sequences': FeatureData[Sequence],
             'taxonomy': FeatureData[Taxonomy]},
     parameters={
-        'random_state': Int % Range(0, None),
         'reads_per_batch': _classify_parameters['reads_per_batch'],
         'n_jobs': _classify_parameters['n_jobs'],
         'confidence': _classify_parameters['confidence']},
@@ -104,7 +103,6 @@ plugin.pipelines.register_function(
         'taxonomy': 'Reference taxonomy to use for classifier '
                     'training/testing.'},
     parameter_descriptions={
-        'random_state': 'Seed used by the random number generator.',
         'reads_per_batch': _parameter_descriptions['reads_per_batch'],
         'n_jobs': _parameter_descriptions['n_jobs'],
         'confidence': _parameter_descriptions['confidence']},


### PR DESCRIPTION
A few minor tweaks:
* fix + enrich installation instructions in readme
* cite general zenodo DOI + badge (instead of release-specific DOI)
* drop `random_state` from `evaluate_fit_classifier` — it is not used if there is no CV!