### PR TITLE
fix taxonomy eval

### DIFF
--- a/rescript/tests/data/real-taxa-test.tsv
+++ b/rescript/tests/data/real-taxa-test.tsv
@@ -1,0 +1,10 @@
+Feature ID	Taxon
+228057	k__Bacteria; p__Proteobacteria; c__Alphaproteobacteria; o__Rickettsiales; f__Pelagibacteraceae; g__; s__
+4424929	k__Bacteria; p__Bacteroidetes; c__[Saprospirae]; o__[Saprospirales]; f__Chitinophagaceae; g__; s__
+4328851	k__Bacteria; p__; c__; o__; f__; g__; s__
+AB600437.1.1389	d__Archaea; p__Aenigmarchaeota; c__Aenigmarchaeia; o__Aenigmarchaeales; f__Aenigmarchaeales; g__Candidatus_Aenigmarchaeum; s__uncultured_archaeon
+HQ774489.1.1456	D_0__Bacteria;D_1__Proteobacteria;D_2__Gammaproteobacteria;D_3__Enterobacteriales;D_4__Enterobacteriaceae;D_5__Klebsiella;D_6__uncultured organism
+AB478667.1.1521	D_0__Bacteria;D_1__Proteobacteria;D_2__Gammaproteobacteria;D_3__Chromatiales;D_4__Chromatiaceae;D_5__Chromatium;D_6__uncultured Chromatiaceae bacterium
+SH1140444.08FU_UDB018513_refs	k__Fungi;p__Basidiomycota;c__Agaricomycetes;o__Thelephorales;f__Thelephoraceae;g__Thelephora;s__Thelephora_alnii
+SH1224192.08FU_KT732156_reps	k__Viridiplantae;p__Anthophyta;c__Monocotyledonae;o__Alismatales;f__Araceae;g__Bucephalandra;s__unidentified
+SH3239536.08FU_UDB0655728_reps_singleton	k__unidentified;p__unidentified;c__unidentified;o__unidentified;f__unidentified;g__unidentified;s__unidentified

--- a/rescript/tests/test_evaluate.py
+++ b/rescript/tests/test_evaluate.py
@@ -95,21 +95,127 @@ class TestEvaluateTaxonomy(TestPluginBase):
                 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 1, 7: 1},
             'Proportion of Features Unclassified at Depth': {
                 1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0, 6: 0.0625, 7: 0.0625}})
+        print(obs.to_dict())
         pdt.assert_frame_equal(obs.sort_index(),
                                exp.sort_index(), check_names=False)
 
     def test_taxonomic_entropy(self):
-        obs_ent = evaluate._taxonomic_entropy(self.taxa.view(pd.Series), "")
+        obs_ent = evaluate._taxonomic_entropy(self.taxa.view(pd.Series), "", 7)
         exp_ent = pd.DataFrame(
             {'Unique Labels': {
-                1: 1.0, 2: 1.0, 3: 1.0, 4: 2.0, 5: 2.0, 6: 3.0, 7: 8.0},
+                1: 1.0, 2: 1.0, 3: 1.0, 4: 2.0, 5: 2.0, 6: 4.0, 7: 9.0},
              'Taxonomic Entropy': {
                 1: 0.0,
                 2: 0.0,
                 3: 0.0,
                 4: 0.6210863745552451,
                 5: 0.6210863745552451,
-                6: 1.0986122886681096,
-                7: 1.9913464134109882}})
+                6: 1.263740679332812,
+                7: 2.1006789212792603}})
+        print(obs_ent)
         pdt.assert_frame_equal(obs_ent.sort_index(),
                                exp_ent.sort_index(), check_names=False)
+
+
+# this test class ensures that _evaluate_taxonomy works with real reference
+# database taxonomies. Add to this list as we validate additional reference
+# databases / taxonomy styles.
+# Currently validated taxonomies:
+# greengenes
+# SILVA
+# UNITE
+class TestEvaluateRealLiveTaxonomies(TestPluginBase):
+    package = 'rescript.tests'
+
+    def setUp(self):
+        super().setUp()
+
+        self.taxa = import_data(
+            'FeatureData[Taxonomy]',
+            self.get_data_path('real-taxa-test.tsv')).view(pd.Series)
+
+    def test_evaluate_taxonomy_real_live_taxonomies_no_rank_handle(self):
+        exp = pd.DataFrame({
+            'Unique Labels': {
+                1: 6.0, 2: 8.0, 3: 8.0, 4: 9.0, 5: 9.0, 6: 9.0, 7: 9.0},
+            'Taxonomic Entropy': {1: 1.6769877743224173, 2: 2.0431918705451206,
+                                  3: 2.0431918705451206, 4: 2.1972245773362196,
+                                  5: 2.1972245773362196, 6: 2.1972245773362196,
+                                  7: 2.1972245773362196},
+            'Number of Features Terminating at Depth': {
+                1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 9},
+            'Proportion of Features Terminating at Depth': {
+                1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0, 6: 0.0, 7: 1.0},
+            'Number of Features Classified at Depth': {
+                1: 9, 2: 9, 3: 9, 4: 9, 5: 9, 6: 9, 7: 9},
+            'Proportion of Features Classified at Depth': {
+                1: 1.0, 2: 1.0, 3: 1.0, 4: 1.0, 5: 1.0, 6: 1.0, 7: 1.0},
+            'Number of Features Unclassified at Depth': {
+                1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0, 7: 0},
+            'Proportion of Features Unclassified at Depth': {
+                1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0, 6: 0.0, 7: 0.0}})
+
+        obs = evaluate._evaluate_taxonomy(self.taxa, rank_handle_regex=None)
+        pdt.assert_frame_equal(obs, exp, check_names=False)
+
+    def test_evaluate_taxonomy_real_live_taxonomies_ggsilva_rank_handle(self):
+        exp = pd.DataFrame({
+            'Unique Labels': {
+                1: 6.0, 2: 8.0, 3: 8.0, 4: 9.0, 5: 9.0, 6: 9.0, 7: 9.0},
+            'Taxonomic Entropy': {1: 1.6769877743224173, 2: 2.0431918705451206,
+                                  3: 2.0431918705451206, 4: 2.1972245773362196,
+                                  5: 2.1972245773362196, 6: 2.1972245773362196,
+                                  7: 2.1972245773362196},
+            'Number of Features Terminating at Depth': {
+                1: 1, 2: 0, 3: 0, 4: 0, 5: 2, 6: 0, 7: 6},
+            'Proportion of Features Terminating at Depth': {
+                1: 0.1111111111111111, 2: 0.0, 3: 0.0, 4: 0.0,
+                5: 0.2222222222222222, 6: 0.0, 7: 0.6666666666666666},
+            'Number of Features Classified at Depth': {
+                1: 9, 2: 8, 3: 8, 4: 8, 5: 8, 6: 6, 7: 6},
+            'Proportion of Features Classified at Depth': {
+                1: 1.0, 2: 0.8888888888888888, 3: 0.8888888888888888,
+                4: 0.8888888888888888, 5: 0.8888888888888888,
+                6: 0.6666666666666666, 7: 0.6666666666666666},
+            'Number of Features Unclassified at Depth': {
+                1: 0, 2: 1, 3: 1, 4: 1, 5: 1, 6: 3, 7: 3},
+            'Proportion of Features Unclassified at Depth': {
+                1: 0.0, 2: 0.1111111111111111, 3: 0.1111111111111111,
+                4: 0.1111111111111111, 5: 0.1111111111111111,
+                6: 0.3333333333333333, 7: 0.3333333333333333}})
+
+        obs = evaluate._evaluate_taxonomy(
+            self.taxa, rank_handle_regex='^[dkpcofgs]__')
+        pdt.assert_frame_equal(obs, exp, check_names=False)
+
+    def test_evaluate_taxonomy_real_live_taxonomies_unite_rank_handle(self):
+        exp = pd.DataFrame({
+            'Unique Labels': {
+                1: 6.0, 2: 8.0, 3: 8.0, 4: 9.0, 5: 9.0, 6: 9.0, 7: 9.0},
+            'Taxonomic Entropy': {1: 1.6769877743224173, 2: 2.0431918705451206,
+                                  3: 2.0431918705451206, 4: 2.1972245773362196,
+                                  5: 2.1972245773362196, 6: 2.1972245773362196,
+                                  7: 2.1972245773362196},
+            'Number of Features Terminating at Depth': {
+                1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 1, 7: 7},
+            'Proportion of Features Terminating at Depth': {
+                1: 0.0, 2: 0.0, 3: 0.0, 4: 0.0, 5: 0.0, 6: 0.1111111111111111,
+                7: 0.7777777777777778},
+            'Number of Features Classified at Depth': {
+                1: 8, 2: 8, 3: 8, 4: 8, 5: 8, 6: 8, 7: 7},
+            'Proportion of Features Classified at Depth': {
+                1: 0.8888888888888888, 2: 0.8888888888888888,
+                3: 0.8888888888888888, 4: 0.8888888888888888,
+                5: 0.8888888888888888, 6: 0.8888888888888888,
+                7: 0.7777777777777778},
+            'Number of Features Unclassified at Depth': {
+                1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 2},
+            'Proportion of Features Unclassified at Depth': {
+                1: 0.1111111111111111, 2: 0.1111111111111111,
+                3: 0.1111111111111111, 4: 0.1111111111111111,
+                5: 0.1111111111111111, 6: 0.1111111111111111,
+                7: 0.2222222222222222}})
+
+        obs = evaluate._evaluate_taxonomy(
+            self.taxa, rank_handle_regex='^[dkpcofgs]__unidentified')
+        pdt.assert_frame_equal(obs, exp, check_names=False)


### PR DESCRIPTION
Fixes a few minor bugs in `evaluate_taxonomy`. These came to light when testing on the UNITE taxonomy — this method was originally validated using greengenes/silva style taxonomies, but testing on UNITE (which has taxonomies like `k__unidentified;p__unidentified;...` a few issues became apparent:
1. redundant taxonomies were not being counted correctly, because the rank depth was counted after casting to a `set`
2. taxonomies without annotation at ANY level were being miscounted (they were counted as classified as the base level, but they are not!)
3. entropy was incorrectly counted if unique counts 

This PR fixes these issues in a few ways:
1. adds some real taxa strings as test data, including UNITE, GG, SILVA, and old-style SILVA. We can add to this list as we test new data sources.
2. tests real data using a few different rank handles (since rank handle trimming can yield empty taxa strings)
3. label counting is done at level 0 (empty string). this level is not plotted, though (as it would be confusing, lead users to think that level 0 is the base level, which it is not).
4. label counting was fixed to not use sets
5. entropy calculations now use a `max_depth` setting to calculate up to and including `max_depth`. Previously max depth was measured on a per-taxon basis, which led to undercounting of empty/truncated taxonomies