### PR TITLE
add evaluate-classifications to evaluate-cross-validate pipeline

### DIFF
--- a/rescript/cross_validate.py
+++ b/rescript/cross_validate.py
@@ -78,6 +78,7 @@ def evaluate_cross_validate(ctx,
 
     fit = ctx.get_action('feature_classifier', 'fit_classifier_naive_bayes')
     classify = ctx.get_action('feature_classifier', 'classify_sklearn')
+    _eval = ctx.get_action('rescript', 'evaluate_classifications')
 
     # split taxonomy into training and test sets
     train_test_data = _generate_train_test_data(taxa, k, random_state)
@@ -110,8 +111,10 @@ def evaluate_cross_validate(ctx,
         'FeatureData[Taxonomy]', pd.concat(expected_taxonomies))
     observed_taxonomies = q2.Artifact.import_data(
         'FeatureData[Taxonomy]', pd.concat(observed_taxonomies))
+    evaluation, = _eval([expected_taxonomies], [observed_taxonomies])
+    _check_time(new_time, 'Evaluation')
     _check_time(start, 'Total Runtime')
-    return expected_taxonomies, observed_taxonomies
+    return expected_taxonomies, observed_taxonomies, evaluation
 
 
 # NOTE: This is an experimental method. Use at your own risk. It appears to be

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -141,7 +141,8 @@ plugin.pipelines.register_function(
         'n_jobs': _classify_parameters['n_jobs'],
         'confidence': _classify_parameters['confidence']},
     outputs=[('expected_taxonomy', FeatureData[Taxonomy]),
-             ('observed_taxonomy', FeatureData[Taxonomy])],
+             ('observed_taxonomy', FeatureData[Taxonomy]),
+             ('evaluation', Visualization)],
     input_descriptions={
         'sequences': 'Reference sequences to use for classifier '
                      'training/testing.',
@@ -158,7 +159,8 @@ plugin.pipelines.register_function(
                              'sequence. Taxonomic labels may be truncated due '
                              'to k-fold CV and stratification.',
         'observed_taxonomy': 'Observed taxonomic label for each input '
-                             'sequence, predicted by cross-validation.'},
+                             'sequence, predicted by cross-validation.',
+        'evaluation': 'Visualization of cross-validated accuracy results.'},
     name=('Evaluate DNA sequence reference database via cross-validated '
           'taxonomic classification.'),
     description=(

--- a/rescript/tests/test_cross_validate.py
+++ b/rescript/tests/test_cross_validate.py
@@ -40,7 +40,7 @@ class TestPipelines(TestPluginBase):
                 '; s__pseudocasei', '').sort_index()
 
     def test_evaluate_cross_validate_k3(self):
-        exp, obs = rescript.actions.evaluate_cross_validate(
+        exp, obs, _ = rescript.actions.evaluate_cross_validate(
             self.seqs, self.taxa, k=3)
         # exp_exp (expected ground truth taxonomies)
         # This will equal the original taxonomy except singleton labels will


### PR DESCRIPTION
e-c-v previously output expected + observed taxonomies. It is already a pipeline — so why not also output a visualization of accuracy results?

This PR adds `evaluate-classifications` to the `evaluate-cross-validate` pipeline so that a visualization of accuracy results is output along with observed/expected results.