### PR TITLE
refactor dereplicate to use skbio for seq subsetting

### DIFF
--- a/rescript/cross_validate.py
+++ b/rescript/cross_validate.py
@@ -25,8 +25,8 @@ def evaluate_fit_classifier(ctx,
                             n_jobs=1,
                             confidence=0.7):
     '''
-    taxonomy: pd.Series of taxonomy labels
-    sequences: pd.Series of sequences
+    taxonomy: FeatureData[Taxonomy] artifact of taxonomy labels
+    sequences: FeatureData[Sequence] artifact of sequences
     k: number of kfold cv splits to perform.
     '''
     # Validate inputs
@@ -66,8 +66,8 @@ def evaluate_cross_validate(ctx,
                             n_jobs=1,
                             confidence=0.7):
     '''
-    taxonomy: pd.Series of taxonomy labels
-    sequences: pd.Series of sequences
+    taxonomy: FeatureData[Taxonomy] artifact of taxonomy labels
+    sequences: FeatureData[Sequence] artifact of sequences
     k: number of kfold cv splits to perform.
     random_state: random state for cv.
     '''

--- a/rescript/dereplicate.py
+++ b/rescript/dereplicate.py
@@ -8,7 +8,8 @@
 
 import tempfile
 import pandas as pd
-import qiime2
+import skbio
+import shutil
 
 from q2_types.feature_data import DNAFASTAFormat
 
@@ -21,7 +22,7 @@ def dereplicate(sequences: DNAFASTAFormat,
                 perc_identity: float = 1.0,
                 threads: int = 1,
                 rank_handles: str = 'silva',
-                derep_prefix: bool = False) -> (pd.Series, pd.DataFrame):
+                derep_prefix: bool = False) -> (DNAFASTAFormat, pd.DataFrame):
     with tempfile.NamedTemporaryFile() as out_fasta:
         with tempfile.NamedTemporaryFile() as out_uc:
             # dereplicate sequences with vsearch
@@ -31,12 +32,11 @@ def dereplicate(sequences: DNAFASTAFormat,
             _vsearch_derep(str(sequences), out_fasta.name, out_uc.name,
                            str(threads), derep_prefix)
             out_uc.seek(0)
-
             uc = _parse_uc(out_uc.name)
 
             # optionally cluster seqs into OTUs
+            clustered_seqs = DNAFASTAFormat()
             if perc_identity < 1.0:
-                clustered_seqs = DNAFASTAFormat()
                 _vsearch_cluster_size(str(out_fasta.name), str(perc_identity),
                                       str(clustered_seqs), out_uc.name,
                                       str(threads))
@@ -47,18 +47,10 @@ def dereplicate(sequences: DNAFASTAFormat,
                 uc['centroidID'] = uc['centroidID'].apply(
                     lambda x: uc_clust.loc[x, 'centroidID'])
             else:
-                clustered_seqs = out_fasta.name
-
-            # open dereplicated fasta and uc file
-            derep_seqs = qiime2.Artifact.import_data(
-                'FeatureData[Sequence]', str(clustered_seqs)).view(pd.Series)
-
-            # transform raw sequences to series for easy parsing
-            sequences = qiime2.Artifact.import_data(
-                'FeatureData[Sequence]', sequences).view(pd.Series)
+                shutil.copyfile(out_fasta.name, str(clustered_seqs))
 
             derep_taxa, seqs_out = _dereplicate_taxa(
-                taxa, sequences, derep_seqs, uc, mode=mode)
+                taxa, sequences, clustered_seqs, uc, mode=mode)
 
             if rank_handles != 'disable':
                 rank_handles = _rank_handles[rank_handles]
@@ -117,6 +109,7 @@ def _parse_uc(uc_fp):
 def _dereplicate_taxa(taxa, raw_seqs, derep_seqs, uc, mode):
     # we only want to grab hits for uniq mode
     if mode == 'uniq':
+        centroid_ids = set(uc['centroidID'].unique())
         uc = uc[uc['seqID'] != uc['centroidID']]
     # map to taxonomy labels
     uc['Taxon'] = uc['seqID'].apply(lambda x: taxa.loc[x])
@@ -128,11 +121,16 @@ def _dereplicate_taxa(taxa, raw_seqs, derep_seqs, uc, mode):
         # drop duplicates that share centroid ID and taxa assignment
         rereplicates = rereplicates.drop_duplicates(['centroidID', 'Taxon'])
         # grab associated seqs
-        rereplicate_seqs = raw_seqs.loc[rereplicates['seqID']]
-        # concatenate with dereplicated seqs
-        seqs_out = pd.concat([derep_seqs, rereplicate_seqs])
+        rereplicate_ids = centroid_ids.union(rereplicates['seqID'].unique())
+        # write out seqs for centroids and daughters with unique taxonomies
+        seqs_out = DNAFASTAFormat()
+        with seqs_out.open() as out_fasta:
+            seq_fp = str(raw_seqs)
+            for s in skbio.read(seq_fp, format='fasta', constructor=skbio.DNA):
+                if s.metadata['id'] in rereplicate_ids:
+                    s.write(out_fasta)
         # generate list of dereplicated taxa
-        derep_taxa = taxa.reindex(seqs_out.index)
+        derep_taxa = taxa.reindex(rereplicate_ids)
 
     else:
         # group seqs that share centroids (this includes the centroid)


### PR DESCRIPTION
fixes #18

replaces pandas with skbio for subsetting large sequence sets. skbio is now used for all sequence processing.

in the process of looking for other places where pandas is used for handing seqs, I found some misleading outdated docstrings in `cross_validate.py` so edited these comments. 

So far it looks like swapping this out did not lead to any real performance improvements (tested dereplicating a large set of sequences) but I did not check memory usage, and the code looks cleaner now without inline artifact imports!