### PR TITLE
add super LCA and majority LCA merging

### DIFF
--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -201,7 +201,7 @@ plugin.methods.register_function(
     function=merge_taxa,
     inputs={'data': List[FeatureData[Taxonomy]]},
     parameters={
-        'mode': Str % Choices(['len', 'lca', 'score']),
+        'mode': Str % Choices(['len', 'lca', 'score', 'super', 'majority']),
         'rank_handle_regex': Str,
         'new_rank_handle': Str % Choices(list(_rank_handles.keys()))},
     outputs=[('merged_data', FeatureData[Taxonomy])],
@@ -215,7 +215,12 @@ plugin.methods.register_function(
                 'taxonomy with the highest score (e.g., confidence or '
                 'consensus score). Note that "score" assumes that this score '
                 'is always contained as the second column in a feature '
-                'taxonomy dataframe.',
+                'taxonomy dataframe. "majority" finds the LCA consensus while '
+                'giving preference to majority labels. "super" finds the LCA '
+                'consensus while giving preference to majority labels and '
+                'collapsing substrings into superstrings (e.g., '
+                '"g__Lactobacillus" would be collapsed with '
+                '"g__Lactobacillus_group_A").',
         'rank_handle_regex': rank_handle_description + rank_handle_extra_note,
         'new_rank_handle': (
             'Specifies the set of rank handles to prepend to taxonomic labels '

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -218,9 +218,11 @@ plugin.methods.register_function(
                 'taxonomy dataframe. "majority" finds the LCA consensus while '
                 'giving preference to majority labels. "super" finds the LCA '
                 'consensus while giving preference to majority labels and '
-                'collapsing substrings into superstrings (e.g., '
-                '"g__Lactobacillus" would be collapsed with '
-                '"g__Lactobacillus_group_A").',
+                'collapsing substrings into superstrings. For example, when a '
+                'more specific taxonomy does not contradict a less specific '
+                'taxonomy, the more specific is chosen. That is, '
+                '"g__Faecalibacterium; s__prausnitzii", will be preferred '
+                'over "g__Faecalibacterium; s__"',
         'rank_handle_regex': rank_handle_description + rank_handle_extra_note,
         'new_rank_handle': (
             'Specifies the set of rank handles to prepend to taxonomic labels '


### PR DESCRIPTION
`merge_taxa` has two new modes:
1. `majority` performs LCA merging, with priority to majority labels
2. `super` performs LCA merging, with priority to majority labels. Labels that are substrings of other labels (including empty rank handles) are collapsed prior to majority/LCA.

In general also includes a decent code refactor and addition of several more tests.