### PR TITLE
IMP: adds super to dereplicate

### DIFF
--- a/rescript/dereplicate.py
+++ b/rescript/dereplicate.py
@@ -13,7 +13,8 @@ import shutil
 
 from q2_types.feature_data import DNAFASTAFormat
 
-from ._utilities import run_command, _find_lca, _majority, _rank_handles
+from ._utilities import (run_command, _find_lca, _majority, _rank_handles,
+                         _find_super_lca)
 
 
 def dereplicate(sequences: DNAFASTAFormat,
@@ -139,7 +140,11 @@ def _dereplicate_taxa(taxa, raw_seqs, derep_seqs, uc, mode):
         if mode == 'lca':
             derep_taxa = derep_taxa.apply(lambda x: ';'.join(
                 _find_lca([y.split(';') for y in x]))).to_frame()
-            # find majority taxon within each cluster
+        # find majority superset LCA within each cluster
+        if mode == 'super':
+            derep_taxa = derep_taxa.apply(lambda x: ';'.join(
+                _find_super_lca([y.split(';') for y in x]))).to_frame()
+        # find majority taxon within each cluster
         elif mode == 'majority':
             derep_taxa = derep_taxa.apply(lambda x: _majority(x)).to_frame()
         # LCA and majority do nothing with the seqs

--- a/rescript/dereplicate.py
+++ b/rescript/dereplicate.py
@@ -141,7 +141,7 @@ def _dereplicate_taxa(taxa, raw_seqs, derep_seqs, uc, mode):
             derep_taxa = derep_taxa.apply(lambda x: ';'.join(
                 _find_lca([y.split(';') for y in x]))).to_frame()
         # find majority superset LCA within each cluster
-        if mode == 'super':
+        elif mode == 'super':
             derep_taxa = derep_taxa.apply(lambda x: ';'.join(
                 _find_super_lca([y.split(';') for y in x]))).to_frame()
         # find majority taxon within each cluster

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -85,6 +85,13 @@ labels_description = (
     'unnamed inputs are labeled numerically in sequential order. Extra '
     'labels are ignored.')
 
+super_lca_desc = (
+    '"super" finds the LCA consensus while giving preference to '
+    'majority labels and collapsing substrings into superstrings. '
+    'For example, when a more specific taxonomy does not '
+    'contradict a less specific taxonomy, the more specific is '
+    'chosen. That is, "g__Faecalibacterium; s__prausnitzii", '
+    'will be preferred over "g__Faecalibacterium; s__"')
 
 plugin.pipelines.register_function(
     function=evaluate_fit_classifier,
@@ -218,13 +225,7 @@ plugin.methods.register_function(
                 'consensus score). Note that "score" assumes that this score '
                 'is always contained as the second column in a feature '
                 'taxonomy dataframe. "majority" finds the LCA consensus while '
-                'giving preference to majority labels. "super" finds the LCA '
-                'consensus while giving preference to majority labels and '
-                'collapsing substrings into superstrings. For example, when a '
-                'more specific taxonomy does not contradict a less specific '
-                'taxonomy, the more specific is chosen. That is, '
-                '"g__Faecalibacterium; s__prausnitzii", will be preferred '
-                'over "g__Faecalibacterium; s__"',
+                'giving preference to majority labels. ' + super_lca_desc,
         'rank_handle_regex': rank_handle_description + rank_handle_extra_note,
         'new_rank_handle': (
             'Specifies the set of rank handles to prepend to taxonomic labels '
@@ -289,13 +290,7 @@ plugin.methods.register_function(
                 'ancestor among all taxa sharing a sequence. "majority" will '
                 'find the most common taxonomic label associated with that '
                 'sequence; note that in the event of a tie, "majority" will '
-                'pick the winner arbitrarily. "super" finds the LCA '
-                'consensus while giving preference to majority labels and '
-                'collapsing substrings into superstrings. For example, when a '
-                'more specific taxonomy does not contradict a less specific '
-                'taxonomy, the more specific is chosen. That is, '
-                '"g__Faecalibacterium; s__prausnitzii", will be preferred '
-                'over "g__Faecalibacterium; s__"',
+                'pick the winner arbitrarily. ' + super_lca_desc,
         'threads': VSEARCH_PARAM_DESCRIPTIONS['threads'],
         'perc_identity': VSEARCH_PARAM_DESCRIPTIONS['perc_identity'],
         'derep_prefix': 'Merge sequences with identical prefixes. If a '

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -272,7 +272,7 @@ plugin.methods.register_function(
     inputs={'sequences': FeatureData[Sequence],
             'taxa': FeatureData[Taxonomy]},
     parameters={
-        'mode': Str % Choices(['uniq', 'lca', 'majority']),
+        'mode': Str % Choices(['uniq', 'lca', 'majority', 'super']),
         'threads': VSEARCH_PARAMS['threads'],
         'perc_identity': VSEARCH_PARAMS['perc_identity'],
         'derep_prefix': Bool,
@@ -289,7 +289,13 @@ plugin.methods.register_function(
                 'ancestor among all taxa sharing a sequence. "majority" will '
                 'find the most common taxonomic label associated with that '
                 'sequence; note that in the event of a tie, "majority" will '
-                'pick the winner arbitrarily.',
+                'pick the winner arbitrarily. "super" finds the LCA '
+                'consensus while giving preference to majority labels and '
+                'collapsing substrings into superstrings. For example, when a '
+                'more specific taxonomy does not contradict a less specific '
+                'taxonomy, the more specific is chosen. That is, '
+                '"g__Faecalibacterium; s__prausnitzii", will be preferred '
+                'over "g__Faecalibacterium; s__"',
         'threads': VSEARCH_PARAM_DESCRIPTIONS['threads'],
         'perc_identity': VSEARCH_PARAM_DESCRIPTIONS['perc_identity'],
         'derep_prefix': 'Merge sequences with identical prefixes. If a '

--- a/rescript/tests/test_derep.py
+++ b/rescript/tests/test_derep.py
@@ -131,6 +131,45 @@ class TestDerep(TestPluginBase):
         pdt.assert_index_equal(seqs.view(pd.Series).sort_index().index,
                                exp_taxa.sort_index().index, check_names=False)
 
+    def test_dereplicate_super_lca_majority(self):
+        seqs, taxa, = self.dereplicate(
+            self.seqs, self.taxa, mode='super', rank_handles='disable')
+        exp_taxa = pd.DataFrame({'Taxon': {
+            'A1': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; '
+                  'f__Paenibacillaceae; g__Paenibacillus; s__alvei',
+            'B1': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales;'
+                  ' f__Lactobacillaceae; g__Lactobacillus; s__casei',
+            'C1': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales;'
+                  ' f__Lactobacillaceae; g__Pediococcus; s__damnosus',
+            'B1a': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales'
+                   '; f__Lactobacillaceae; g__Lactobacillus; s__vaginalis',
+            'B1b': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales'
+                   '; f__Lactobacillaceae; g__Lactobacillus; s__pseudocasei',
+            'C1a': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales'
+                   '; f__Lactobacillaceae; g__Pediococcus; s__acidilacti'}})
+        pdt.assert_frame_equal(taxa.view(pd.DataFrame).sort_index(),
+                               exp_taxa.sort_index(), check_names=False)
+        pdt.assert_index_equal(seqs.view(pd.Series).sort_index().index,
+                               exp_taxa.sort_index().index, check_names=False)
+
+    def test_dereplicate_super_lca_majority_perc99(self):
+        seqs, taxa, = self.dereplicate(self.seqs, self.taxa, mode='super',
+                                       perc_identity=0.99,
+                                       rank_handles='disable')
+        exp_taxa = pd.DataFrame({'Taxon': {
+            'A1': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Bacillales; '
+                  'f__Paenibacillaceae; g__Paenibacillus; s__alvei',
+            'B1': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales;'
+                  ' f__Lactobacillaceae; g__Lactobacillus; s__casei',
+            'C1': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales;'
+                  ' f__Lactobacillaceae; g__Pediococcus; s__acidilacti',
+            'B1b': 'k__Bacteria; p__Firmicutes; c__Bacilli; o__Lactobacillales'
+                   '; f__Lactobacillaceae; g__Lactobacillus; s__pseudocasei'}})
+        pdt.assert_frame_equal(taxa.view(pd.DataFrame).sort_index(),
+                               exp_taxa.sort_index(), check_names=False)
+        pdt.assert_index_equal(seqs.view(pd.Series).sort_index().index,
+                               exp_taxa.sort_index().index, check_names=False)
+
     # test that LCA taxonomy assignment works when derep_prefix=True
     # here derep_prefix + LCA leads to collapsed C-group seqs + LCA taxonomy
     def test_dereplicate_prefix_lca(self):


### PR DESCRIPTION
Adds the same "super"  mode of `merge_taxa` to `dereplicate` for taxonomy dereplication. Help text was updated and two tests cases added.