### PR TITLE
added filter-taxa method

### DIFF
--- a/rescript/filter_length.py
+++ b/rescript/filter_length.py
@@ -110,12 +110,10 @@ def filter_taxa(taxonomy: pd.Series, ids_to_keep: qiime2.Metadata = None,
         _index_is_superset(set(ids_to_keep), ids)
 
     if include:
-        include = '|'.join(include)
-        ids = ids[taxonomy.str.contains(include.replace(',', '|'))]
+        ids = ids[taxonomy.str.contains('|'.join(include))]
 
     if exclude:
-        exclude = '|'.join(exclude)
-        bad = taxonomy.index[taxonomy.str.contains(exclude.replace(',', '|'))]
+        bad = taxonomy.index[taxonomy.str.contains('|'.join(exclude))]
         ids = ids.difference(bad)
 
     # if not using exclude or include, we only want explicit ids_to_keep

--- a/rescript/filter_length.py
+++ b/rescript/filter_length.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import qiime2
 import pandas as pd
 from q2_types.feature_data import DNAFASTAFormat, DNAIterator
 
@@ -96,6 +97,47 @@ def filter_seqs_length_by_taxon(sequences: DNAFASTAFormat,
     return result, failures
 
 
+def filter_taxa(taxonomy: pd.Series, ids_to_keep: qiime2.Metadata = None,
+                include: str = None, exclude: str = None) -> pd.Series:
+    if include is exclude is ids_to_keep is None:
+        raise ValueError('No filtering criteria were applied!')
+
+    ids = taxonomy.index
+    print('Input features: ' + str(len(ids)))
+    # some initial validation
+    if ids_to_keep:
+        ids_to_keep = ids_to_keep.ids
+        _index_is_superset(set(ids_to_keep), ids)
+
+    if include:
+        include = '|'.join(include)
+        ids = ids[taxonomy.str.contains(include.replace(',', '|'))]
+
+    if exclude:
+        exclude = '|'.join(exclude)
+        bad = taxonomy.index[taxonomy.str.contains(exclude.replace(',', '|'))]
+        ids = ids.difference(bad)
+
+    # if not using exclude or include, we only want explicit ids_to_keep
+    if include is exclude is None:
+        ids = ids_to_keep
+    # otherwise add back ids_to_keep for explicit inclusion after filtering
+    elif ids_to_keep:
+        ids = ids.union(ids_to_keep)
+
+    filtered_ids = len(ids)
+    print('Output features: ' + str(filtered_ids))
+
+    if filtered_ids == 0:
+        raise ValueError("All features were filtered, resulting in an "
+                         "empty collection of taxonomies.")
+
+    taxonomy = taxonomy.reindex(ids)
+    taxonomy.index.name = 'Feature ID'
+
+    return taxonomy
+
+
 def _seq_length_within_range(sequence, taxahits, mins, maxs, global_min,
                              global_max):
     '''
@@ -155,5 +197,5 @@ def _index_is_superset(index1, index2):
     '''
     diff = index1.difference(index2)
     if len(diff) > 0:
-        raise ValueError('The following sequences are missing from '
+        raise ValueError('The following IDs are missing from '
                          'the taxonomy: ' + ', '.join(sorted(diff)))

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -20,7 +20,8 @@ from .get_data import get_silva_data
 from .cross_validate import (evaluate_cross_validate,
                              evaluate_classifications,
                              evaluate_fit_classifier)
-from .filter_length import filter_seqs_length_by_taxon, filter_seqs_length
+from .filter_length import (filter_seqs_length_by_taxon, filter_seqs_length,
+                            filter_taxa)
 from .orient import orient_seqs
 from q2_types.feature_data import (FeatureData, Taxonomy, Sequence,
                                    AlignedSequence)
@@ -714,6 +715,32 @@ plugin.methods.register_function(
         'database and download, parse, and import the corresponding '
         'taxonomies from the NCBI Taxonomy database.'),
     citations=[citations['ncbi2018database'], citations['benson2012genbank']]
+)
+
+
+plugin.methods.register_function(
+    function=filter_taxa,
+    inputs={'taxonomy': FeatureData[Taxonomy]},
+    parameters={
+        'ids_to_keep': Metadata,
+        'include': List[Str],
+        'exclude': List[Str]},
+    outputs=[('filtered_taxonomy', FeatureData[Taxonomy])],
+    input_descriptions={'taxonomy': 'Taxonomy to filter.'},
+    parameter_descriptions={
+        'ids_to_keep': 'List of IDs to keep (as Metadata). Selecting these '
+                       'IDs occurs after inclusion and exclusion filtering.',
+        'include': 'List of search terms. Taxa containing one or more of '
+                   'these terms will be retained. Inclusion filtering occurs '
+                   'prior to exclusion filtering and selecting `ids_to_keep`.',
+        'exclude': 'List of search terms. Taxa containing one or more of '
+                   'these terms will be excluded. Exclusion filtering occurs '
+                   'after inclusion filtering and prior to selecting '
+                   '`ids_to_keep`.'},
+    output_descriptions={
+        'filtered_taxonomy': 'The filtered taxonomy.'},
+    name='Filter taxonomy by list of IDs or search criteria.',
+    description=('Filter taxonomy by list of IDs or search criteria.'),
 )
 
 


### PR DESCRIPTION
allows filtering a `FeatureData[Taxonomy]` artifact based on one or more search criteria.

I decided to add this because, while Q2 style is to typically just subset taxonomy, RESCRIPt evaluate taxonomy methods sometimes require taxonomy to be subset (e.g., if evaluating a specific clade, and some methods do not allow superset taxonomies, e.g.,` evaluate-classifications`)