### PR TITLE
IMP: add fasta subsampling action

### DIFF
--- a/rescript/_utilities.py
+++ b/rescript/_utilities.py
@@ -107,6 +107,10 @@ def _read_dna_fasta(path):
     return skbio.read(path, format='fasta', constructor=skbio.DNA)
 
 
+def _read_dna_alignment_fasta(path):
+    return skbio.TabularMSA.read(path, format='fasta', constructor=skbio.DNA)
+
+
 def _rna_to_dna(path):
     ff = DNAFASTAFormat()
     with ff.open() as outfasta:

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -8,9 +8,11 @@
 
 import importlib
 
+from qiime2.core.type import TypeMatch
 from qiime2.plugin import (Str, Plugin, Choices, List, Citations, Range, Int,
                            Float, Visualization, Bool, TypeMap, Metadata)
 
+from .subsample import subsample_fasta
 from .trim_alignment import trim_alignment
 from .merge import merge_taxa
 from .dereplicate import dereplicate
@@ -826,6 +828,34 @@ plugin.pipelines.register_function(
         "Subsequently, start (5'-most) and end (3'-most) position from fwd "
         "and rev primer located within the new alignment is identified and "
         "used for slicing the original alignment."),
+)
+
+T = TypeMatch([AlignedSequence])
+plugin.methods.register_function(
+    function=subsample_fasta,
+    inputs={'sequences': FeatureData[T], },
+    parameters={
+        'subsample_size':
+            Float % Range(0, 1, inclusive_start=False, inclusive_end=True) |
+            Int % Range(1, None),
+        'random_seed': Int % Range(1, None)
+    },
+    outputs=[('sample_sequences', FeatureData[T]), ],
+    input_descriptions={'sequences': 'Sequences to subsample from.', },
+    parameter_descriptions={
+        'subsample_size': 'Size of the sample: if a number 0.0-1.0 is given '
+                          'a corresponding fraction of sequences will be '
+                          'sampled. If an integer >1 is given, a corresponding'
+                          'number of sequences will be sampled.',
+        'random_seed': 'Seed to be used for random sampling.'
+    },
+    output_descriptions={
+        'sample_sequences': 'Sample of original sequences.', },
+    name='Subsample an indicated number of sequences from a FASTA file.',
+    description=(
+        "Subsample a set of sequences (either plain or aligned DNA)"
+        "based on the number of desired sequences or a fraction of "
+        "original sequences."),
 )
 
 # Registrations

--- a/rescript/subsample.py
+++ b/rescript/subsample.py
@@ -1,0 +1,49 @@
+import random
+from typing import Union
+
+from q2_types.feature_data import (AlignedDNAFASTAFormat, DNAFASTAFormat)
+
+from rescript._utilities import _read_dna_fasta, _read_dna_alignment_fasta
+
+
+def _read_seqs(sequences: Union[DNAFASTAFormat, AlignedDNAFASTAFormat]):
+    return _read_dna_fasta(str(sequences)) if isinstance(
+        sequences, DNAFASTAFormat) else _read_dna_alignment_fasta(
+        str(sequences))
+
+
+def subsample_fasta(sequences: AlignedDNAFASTAFormat,
+                    subsample_size: Union[float, int] = 0.1,
+                    random_seed: int = 42) -> \
+        AlignedDNAFASTAFormat:
+    # set seed for reproducibility
+    random.seed(random_seed)
+
+    # get all ids
+    seqs_iter = _read_seqs(sequences)
+    ids = [seq.metadata['id'] for seq in seqs_iter]
+
+    # get a sample of the ids
+    if isinstance(subsample_size, float):
+        ids_sample = set(random.sample(ids, int(subsample_size * len(ids))))
+    else:
+        if subsample_size <= len(ids):
+            ids_sample = set(random.sample(ids, subsample_size))
+        else:
+            raise ValueError(f"The requested sample size {subsample_size} "
+                             f"is bigger than the total number of "
+                             f"sequences {len(ids)}")
+
+    # write out sampled sequences
+    result = DNAFASTAFormat() if isinstance(
+        sequences, DNAFASTAFormat) else AlignedDNAFASTAFormat()
+
+    seqs_iter = _read_seqs(sequences)
+    with result.open() as out_fasta:
+        for seq in seqs_iter:
+            id = seq.metadata['id']
+            if id in ids_sample:
+                seq.write(out_fasta)
+                ids_sample.remove(id)
+
+    return result


### PR DESCRIPTION
This PR adds a `subsample-fasta` action that can be used to randomly sample from FASTA (either plain or aligned DNA). User can define either a fraction of the original sequence count or a number of sequences they want the sample to have.

Some open question/comments:
1. I tried to use the TypeMatch to make it work with both, plain and aligned, DNA sequences but I seem to be unable to make it work when it comes to setting the correct types in the `subsample_fasta` function definition (tried with Union, doesn't work) - hoping for some hints here :)
2. this implementation is a bit different from the [suggested solution](https://github.com/biocore/qiime/blob/76d633c0389671e93febbe1338b5ded658eba31f/qiime/util.py#L1536) so that:
- it is possible to specify an absolute number of sequences to sample
- the sample always contains the exact number of sequences (with the above approach it is not guaranteed)