### PR TITLE
ENH: use add-fragments flag when aligning primers for trimming

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020, QIIME 2 development team.
+Copyright (c) 2021, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/rescript/__init__.py
+++ b/rescript/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/_utilities.py
+++ b/rescript/_utilities.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/cross_validate.py
+++ b/rescript/cross_validate.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/degap.py
+++ b/rescript/degap.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/dereplicate.py
+++ b/rescript/dereplicate.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/evaluate.py
+++ b/rescript/evaluate.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/filter_length.py
+++ b/rescript/filter_length.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -149,7 +149,7 @@ def _validate_md5(exp_md5, file_md5, filename):
         raise ValueError('md5 sums do not match. Manually verify md5 sums '
                          'before proceeding.\nTarget file: {0}\nExpected md5: '
                          '{1}\nObserved md5: {2}\n'.format(
-                            filename, exp_md5, file_md5))
+                             filename, exp_md5, file_md5))
 
 
 # This function is specific for reading the SILVA md5 record files, which are

--- a/rescript/merge.py
+++ b/rescript/merge.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/ncbi.py
+++ b/rescript/ncbi.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -74,7 +74,7 @@ def get_ncbi_data(
         query: str = None, accession_ids: Metadata = None,
         ranks: list = None, rank_propagation: bool = True,
         logging_level: str = None, n_jobs: int = 1
-        ) -> (DNAIterator, DataFrame):
+) -> (DNAIterator, DataFrame):
     if ranks is None:
         ranks = _default_ranks
     if query is None and accession_ids is None:

--- a/rescript/orient.py
+++ b/rescript/orient.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/parse_silva_taxonomy.py
+++ b/rescript/parse_silva_taxonomy.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -98,7 +98,7 @@ def _prep_taxmap(taxmap):
     taxmap.index.name = 'Feature ID'
     taxmap = taxmap.loc[:, ['organism_name', 'taxid']]
     taxmap.loc[:, 'organism_name'] = taxmap.loc[:, 'organism_name'].apply(
-                                            _get_clean_organism_name)
+        _get_clean_organism_name)
     return taxmap
 
 
@@ -116,7 +116,7 @@ def _prep_taxranks(taxrank):
     taxrank.set_index('taxid', inplace=True)
     # return only the last taxonomy from a given taxonomy path
     taxrank.loc[:, 'taxid_taxonomy'] = taxrank.loc[:, 'taxid_taxonomy'].apply(
-                                             _get_terminal_taxon)
+        _get_terminal_taxon)
     return taxrank
 
 
@@ -166,7 +166,7 @@ def _compile_taxonomy_output(updated_taxmap, ranks,
         updated_taxmap.loc[:, sorted_ranks].apply(lambda x: x.name + x)
     if include_species_labels:
         updated_taxmap.loc[:, 'organism_name'] = updated_taxmap.loc[
-                           :, 'organism_name'].apply(lambda x: 's__' + x)
+            :, 'organism_name'].apply(lambda x: 's__' + x)
         sorted_ranks.append('organism_name')
     taxonomy = updated_taxmap.loc[:, sorted_ranks].agg('; '.join, axis=1)
     taxonomy.rename('Taxon', inplace=True)

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/screenseq.py
+++ b/rescript/screenseq.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/subsample.py
+++ b/rescript/subsample.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/__init__.py
+++ b/rescript/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_cross_validate.py
+++ b/rescript/tests/test_cross_validate.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_degap.py
+++ b/rescript/tests/test_degap.py
@@ -25,8 +25,7 @@ class TestDegapSeq(TestPluginBase):
         super().setUp()
         input_fp = self.get_data_path('degap-test-alignment.fasta')
         self.alignedseqs = AlignedDNAFASTAFormat(
-            input_fp, mode='r').view(
-            AlignedDNAIterator)
+            input_fp, mode='r').view(AlignedDNAIterator)
 
     def test_degap_seqs(self):
         #  remove all '-' and '.' chars.

--- a/rescript/tests/test_degap.py
+++ b/rescript/tests/test_degap.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -25,8 +25,8 @@ class TestDegapSeq(TestPluginBase):
         super().setUp()
         input_fp = self.get_data_path('degap-test-alignment.fasta')
         self.alignedseqs = AlignedDNAFASTAFormat(
-                                input_fp, mode='r').view(
-                                AlignedDNAIterator)
+            input_fp, mode='r').view(
+            AlignedDNAIterator)
 
     def test_degap_seqs(self):
         #  remove all '-' and '.' chars.

--- a/rescript/tests/test_derep.py
+++ b/rescript/tests/test_derep.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_evaluate.py
+++ b/rescript/tests/test_evaluate.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_filter_length.py
+++ b/rescript/tests/test_filter_length.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_get_data.py
+++ b/rescript/tests/test_get_data.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_merge.py
+++ b/rescript/tests/test_merge.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -182,7 +182,7 @@ class TestMergeTaxa(TestPluginBase):
                 '2562091': np.nan, '2562097': 0.9, '370253': 0.95,
                 '4361279': np.nan, '4369464': 0.99, 'unique': np.nan,
                 'unique1': 0.75, 'unique2': np.nan}
-            })], axis=1)
+        })], axis=1)
         multi_col, = self.merge_taxa([self.m1, self.m2, self.m3], 'len', '')
         multi_col = multi_col.view(pd.DataFrame).apply(
             lambda x: pd.to_numeric(x, errors='ignore'))

--- a/rescript/tests/test_ncbi.py
+++ b/rescript/tests/test_ncbi.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -133,9 +133,9 @@ class TestNCBI(TestPluginBase):
         md = Metadata(df)
 
         acc_seq, acc_tax = self.get_ncbi_data(
-                accession_ids=md,
-                ranks=['subkingdom', 'subphylum', 'subclass', 'suborder',
-                       'subfamily', 'subgenus', 'subspecies'])
+            accession_ids=md,
+            ranks=['subkingdom', 'subphylum', 'subclass', 'suborder',
+                   'subfamily', 'subgenus', 'subspecies'])
         acc_seq = {s.metadata['id']: str(s) for s in acc_seq.view(DNAIterator)}
         seqs = {s.metadata['id']: str(s) for s in self.seqs.view(DNAIterator)}
         self.assertEqual(acc_seq, seqs)

--- a/rescript/tests/test_orient.py
+++ b/rescript/tests/test_orient.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_parse_silva_taxonomy.py
+++ b/rescript/tests/test_parse_silva_taxonomy.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -70,7 +70,7 @@ class TestParseSilvaTaxonomy(TestPluginBase):
         sx_1 = 'Glaciecola_sp._105'
         self.assertEqual(se_1, sx_1)
         se_2 = _keep_allowed_chars(
-               'Acetobacterium sp. enrichment culture clone DhR^2/LM-A07')
+            'Acetobacterium sp. enrichment culture clone DhR^2/LM-A07')
         sx_2 = 'Acetobacterium_sp._enrichment_culture_clone_DhR2/LM-A07'
         self.assertEqual(se_2, sx_2)
         se_3 = _keep_allowed_chars('Pseudomonas poae RE*1-1-14')
@@ -82,7 +82,7 @@ class TestParseSilvaTaxonomy(TestPluginBase):
 
     def test_get_terminal_taxon(self):
         term_tax = _get_terminal_taxon(
-                    'Archaea;Aenigmarchaeota;Aenigmarchaeia;Aenigmarchaeales;')
+            'Archaea;Aenigmarchaeota;Aenigmarchaeia;Aenigmarchaeales;')
         exp_term_tax = 'Aenigmarchaeales'
         self.assertEqual(term_tax, exp_term_tax)
 

--- a/rescript/tests/test_screenseq.py
+++ b/rescript/tests/test_screenseq.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_subsample.py
+++ b/rescript/tests/test_subsample.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/tests/test_trim_alignment.py
+++ b/rescript/tests/test_trim_alignment.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/trim_alignment.py
+++ b/rescript/trim_alignment.py
@@ -219,10 +219,10 @@ def _trim_alignment(expand_alignment_action,
             'FeatureData[Sequence]', primers_fasta)
 
         # expand the existing alignment by addition of primers
-        alignment_with_primers = expand_alignment_action(
+        alignment_with_primers, = expand_alignment_action(
             alignment=aligned_sequences,
             sequences=primers,
-            addfragments=True)[0]
+            addfragments=True)
 
         # find trim positions based on primer positions within alignment
         trim_positions = _locate_primer_positions(alignment_with_primers)

--- a/rescript/trim_alignment.py
+++ b/rescript/trim_alignment.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/trim_alignment.py
+++ b/rescript/trim_alignment.py
@@ -220,7 +220,9 @@ def _trim_alignment(expand_alignment_action,
 
         # expand the existing alignment by addition of primers
         alignment_with_primers = expand_alignment_action(
-            alignment=aligned_sequences, sequences=primers)[0]
+            alignment=aligned_sequences,
+            sequences=primers,
+            addfragments=True)[0]
 
         # find trim positions based on primer positions within alignment
         trim_positions = _locate_primer_positions(alignment_with_primers)

--- a/rescript/types/__init__.py
+++ b/rescript/types/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/types/_format.py
+++ b/rescript/types/_format.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/types/_transformer.py
+++ b/rescript/types/_transformer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/types/_type.py
+++ b/rescript/types/_type.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/types/methods.py
+++ b/rescript/types/methods.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/types/tests/__init__.py
+++ b/rescript/types/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/types/tests/test_methods.py
+++ b/rescript/types/tests/test_methods.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/rescript/types/tests/test_types_formats_transformers.py
+++ b/rescript/types/tests/test_types_formats_transformers.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2020, QIIME 2 development team.
+# Copyright (c) 2021, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #


### PR DESCRIPTION
Adds the `addfragments` support (introduced in q2-alignment: https://github.com/qiime2/q2-alignment/pull/71/) when aligning primers before trimming sequences. 

Updates the year info in the licensing part of all files.