### PR TITLE
added LSU-138 to get-silva-data

### DIFF
--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -52,6 +52,7 @@ def _assemble_silva_data_urls(version, target, download_sequences=True):
     ref_map = {'SSURef_NR99': 'ssu_ref_nr',
                'SSURef_Nr99': 'ssu_ref_nr',
                'SSURef': 'ssu_ref',
+               'LSURef_NR99': 'lsu_ref_nr',
                'LSURef': 'lsu_ref'}
     # handle silly inconsistencies in filenames between versions
     if target == 'SSURef_NR99' and float(version) < 138:

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -592,13 +592,14 @@ RANK_DESCRIPTION = ('List of taxonomic ranks for building a taxonomy from the '
                     "', '".join(DEFAULT_RANKS) + "']")
 
 _SILVA_VERSIONS = ['128', '132', '138', '138.1']
-_SILVA_TARGETS = ['SSURef_NR99', 'SSURef', 'LSURef']
+_SILVA_TARGETS = ['SSURef_NR99', 'SSURef', 'LSURef_NR99', 'LSURef']
 
 version_map, target_map, _ = TypeMap({
     (Str % Choices('128', '132'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef')): Visualization,
-    (Str % Choices('138', '138.1'), Str % Choices('SSURef_NR99', 'SSURef')):
-        Visualization,
+    (Str % Choices('138', '138.1'),
+     Str % Choices('SSURef_NR99', 'SSURef', 'LSURef_NR99',
+                   'LSURef')): Visualization,
 })
 
 

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -597,7 +597,9 @@ _SILVA_TARGETS = ['SSURef_NR99', 'SSURef', 'LSURef_NR99', 'LSURef']
 version_map, target_map, _ = TypeMap({
     (Str % Choices('128', '132'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef')): Visualization,
-    (Str % Choices('138', '138.1'),
+    (Str % Choices('138'),
+     Str % Choices('SSURef_NR99', 'SSURef')): Visualization,
+    (Str % Choices('138.1'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef_NR99',
                    'LSURef')): Visualization,
 })

--- a/rescript/tests/test_get_data.py
+++ b/rescript/tests/test_get_data.py
@@ -27,7 +27,9 @@ class TestGetSILVA(TestPluginBase):
             for target in _SILVA_TARGETS:
                 # don't test incompatible version/target settings (these are
                 # prevented in the user interface by TypeMap)
-                if target == 'LSURef' and version == '138':
+                if target == 'LSURef' or 'LSURef_NR99' and version == '138':
+                    continue
+                elif target == 'LSURef_NR99' and version == '128' or '132':
                     continue
                 obs = _assemble_silva_data_urls(version, target)
                 # validate URLs


### PR DESCRIPTION
Adds the ability to fetch LSURef and LSURef_NR99 from Silva 138.1.

Fixes issue #97 

