### PR TITLE
issue-98 : updated minimum qiime 2 version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ pip install git+https://github.com/bokulich-lab/RESCRIPt.git
 ```
 
 ### Option 2: Install within QIIME 2 environment
-First activate your QIIME 2 environment (ver 2020.8 or later) and install relevant dependencies:
+First activate your QIIME 2 environment (ver 2021.2 or later) and install relevant dependencies:
 
 ```
-conda activate qiime2-2020.8
+conda activate qiime2-2021.2
 conda install -c conda-forge -c bioconda -c qiime2 -c defaults xmltodict
 ```
 Install source:


### PR DESCRIPTION
Sets minimum QIIME 2 version to `2021.2`. Fixes #98 

Is there anything else that we should add / change within docs of this PR?