### PR TITLE
BUG: fix 'Taxon' column to always be first after merge

### DIFF
--- a/rescript/_utilities.py
+++ b/rescript/_utilities.py
@@ -72,7 +72,7 @@ def _rank_length(t1, t2):
 
 
 def _find_top_score(t1, t2):
-    return t1 if t1['score'] > t2['score'] else t2
+    return t1 if t1['Score'] > t2['Score'] else t2
 
 
 def _taxon_to_list(taxon, rank_handle):

--- a/rescript/merge.py
+++ b/rescript/merge.py
@@ -23,10 +23,13 @@ def merge_taxa(data: pd.DataFrame,
                mode: str = 'len',
                rank_handle_regex: str = '^[dkpcofgs]__',
                new_rank_handle: str = None) -> pd.DataFrame:
-    # Convert taxonomies to list; optionally remove rank handle
     for d in data:
+        # Convert taxonomies to list; optionally remove rank handle
         d['Taxon'] = d['Taxon'].apply(
             lambda x: _taxon_to_list(x, rank_handle=rank_handle_regex))
+
+        # Capitalize column names for sorting consistency
+        d.columns = [x.capitalize() for x in d.columns]
 
     # consensus and other dataset-specific data are meaningless after LCA
     # or majority so we will just drop them and apply functions across rows.
@@ -53,7 +56,7 @@ def merge_taxa(data: pd.DataFrame,
             func, fill_value, overwrite = _find_top_score, 0, True
             for d in data:
                 try:
-                    d['score'] = pd.to_numeric(d.iloc[:, 1])
+                    d['Score'] = pd.to_numeric(d.iloc[:, 1])
                 # if single-column frame is encountered, raise error
                 except IndexError:
                     raise IndexError(MODE_ERROR_SCORE)
@@ -62,6 +65,9 @@ def merge_taxa(data: pd.DataFrame,
         for d in data:
             result = result.T.combine(
                 d.T, func, fill_value=fill_value, overwrite=overwrite).T
+            reordered_cols = ['Taxon'] + [x for x in result.columns
+                                          if x != 'Taxon']
+            result = result[reordered_cols]
 
     # Insert new rank handles if selected
     if new_rank_handle is not None:

--- a/rescript/tests/test_merge.py
+++ b/rescript/tests/test_merge.py
@@ -71,7 +71,7 @@ class TestMergeTaxa(TestPluginBase):
                            'f__Rhizobiaceae; g__Rhizobium; s__leguminosarum',
                 # test merging unique feature (only found in dataframe b)
                 'unique1': 'k__Bacteria; p__; c__; o__; f__; g__; s__blah'},
-            'consensus': {
+            'Consensus': {
                 '370253': 0.95,
                 '2562097': 0.9,
                 '2562091': 0.85,
@@ -174,11 +174,11 @@ class TestMergeTaxa(TestPluginBase):
         pdt.assert_frame_equal(
             one_col.view(pd.DataFrame), exp, check_names=False)
         exp = pd.concat([exp, pd.DataFrame({
-            'confidence': {
+            'Confidence': {
                 '2562091': 1.0, '2562097': np.nan, '370253': np.nan,
                 '4361279': 0.9, '4369464': np.nan, 'unique': 0.76,
                 'unique1': np.nan, 'unique2': 0.77},
-            'consensus': {
+            'Consensus': {
                 '2562091': np.nan, '2562097': 0.9, '370253': 0.95,
                 '4361279': np.nan, '4369464': 0.99, 'unique': np.nan,
                 'unique1': 0.75, 'unique2': np.nan}
@@ -209,10 +209,10 @@ class TestMergeTaxa(TestPluginBase):
                 'unique': 'Bacteria;;;;;;blah',
                 'unique1': 'Bacteria;;;;;;blah',
                 'unique2': 'Bacteria;;;;;;blah'},
-            'confidence': {'2562091': 1.0, '2562097': np.nan, '370253': 1.0,
+            'Confidence': {'2562091': 1.0, '2562097': np.nan, '370253': 1.0,
                            '4361279': 0.9, '4369464': np.nan, 'unique': 0.76,
                            'unique1': np.nan, 'unique2': 0.77},
-            'consensus': {'2562091': np.nan, '2562097': 0.9, '370253': np.nan,
+            'Consensus': {'2562091': np.nan, '2562097': 0.9, '370253': np.nan,
                           '4361279': np.nan, '4369464': 0.99, 'unique': np.nan,
                           'unique1': 0.75, 'unique2': np.nan}})
         result = result.view(pd.DataFrame).apply(
@@ -244,10 +244,10 @@ class TestMergeTaxa(TestPluginBase):
                 'unique': 'k__Bacteria;p__;c__;o__;f__;g__;s__blah',
                 'unique1': 'k__Bacteria;p__;c__;o__;f__;g__;s__blah',
                 'unique2': 'k__Bacteria;p__;c__;o__;f__;g__;s__blah'},
-            'confidence': {'2562091': 1.0, '2562097': np.nan, '370253': 1.0,
+            'Confidence': {'2562091': 1.0, '2562097': np.nan, '370253': 1.0,
                            '4361279': 0.9, '4369464': np.nan, 'unique': 0.76,
                            'unique1': np.nan, 'unique2': 0.77},
-            'consensus': {'2562091': np.nan, '2562097': 0.9, '370253': np.nan,
+            'Consensus': {'2562091': np.nan, '2562097': 0.9, '370253': np.nan,
                           '4361279': np.nan, '4369464': 0.99, 'unique': np.nan,
                           'unique1': 0.75, 'unique2': np.nan}})
         result = result.view(pd.DataFrame).apply(
@@ -279,13 +279,13 @@ class TestMergeTaxa(TestPluginBase):
                 'unique': 'k__Bacteria;p__;c__;o__;f__;g__;s__blah',
                 'unique1': 'k__Bacteria;p__;c__;o__;f__;g__;s__blah',
                 'unique2': 'k__Bacteria;p__;c__;o__;f__;g__;s__blah'},
-            'confidence': {
+            'Confidence': {
                 '2562091': 1.0, '2562097': 0.99, '370253': 1.0, '4361279': 0.9,
                 '4369464': 0, 'unique': 0.76, 'unique1': 0, 'unique2': 0.77},
-            'consensus': {
+            'Consensus': {
                 '2562091': 0, '2562097': 0, '370253': 0, '4361279': 0,
                 '4369464': 0.99, 'unique': 0, 'unique1': 0.75, 'unique2': 0},
-            'score': {
+            'Score': {
                 '2562091': 1.0, '2562097': 0.99, '370253': 1.0, '4361279': 0.9,
                 '4369464': 0.99, 'unique': 0.76, 'unique1': 0.75,
                 'unique2': 0.77}})


### PR DESCRIPTION
When the DataFrames get _combined_ the columns will be sorted alphabetically, with the preference to first sort the capitalized column names and only then the other ones. That causes the column 'Taxa' to loose its position as a first column (required) when the other column names were provided as capitalized words.

Changes introduced in this PR allow to first capitalize all the column names to ensure consistent sorting behaviour during merge and then ensure that the 'Taxon' column is always first, regardless of the other columns. The tests were adjusted to reflect this behaviour.

Closes #112. 