### PR TITLE
BUG: set unresolved taxonomies to 'Unassigned'

### DIFF
--- a/rescript/merge.py
+++ b/rescript/merge.py
@@ -71,6 +71,9 @@ def merge_taxa(data: pd.DataFrame,
     else:
         result['Taxon'] = result['Taxon'].apply(lambda x: ';'.join(x))
 
+    # fill unassigned taxa, if any
+    result['Taxon'].replace('', 'Unassigned', inplace=True)
+
     # gotta please the type validator gods
     result.index.name = 'Feature ID'
 

--- a/rescript/merge.py
+++ b/rescript/merge.py
@@ -22,7 +22,8 @@ MODE_ERROR_SCORE = (
 def merge_taxa(data: pd.DataFrame,
                mode: str = 'len',
                rank_handle_regex: str = '^[dkpcofgs]__',
-               new_rank_handle: str = None) -> pd.DataFrame:
+               new_rank_handle: str = None,
+               unclassified_label: str = 'Unassigned') -> pd.DataFrame:
     # Convert taxonomies to list; optionally remove rank handle
     for d in data:
         d['Taxon'] = d['Taxon'].apply(
@@ -72,7 +73,7 @@ def merge_taxa(data: pd.DataFrame,
         result['Taxon'] = result['Taxon'].apply(lambda x: ';'.join(x))
 
     # fill unassigned taxa, if any
-    result['Taxon'].replace('', 'Unassigned', inplace=True)
+    result['Taxon'].replace('', unclassified_label, inplace=True)
 
     # gotta please the type validator gods
     result.index.name = 'Feature ID'

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -222,7 +222,9 @@ plugin.methods.register_function(
     parameters={
         'mode': Str % Choices(['len', 'lca', 'score', 'super', 'majority']),
         'rank_handle_regex': Str,
-        'new_rank_handle': Str % Choices(list(_rank_handles.keys()))},
+        'new_rank_handle': Str % Choices(list(_rank_handles.keys())),
+        'unclassified_label': Str
+    },
     outputs=[('merged_data', FeatureData[Taxonomy])],
     input_descriptions={
         'data': 'Two or more feature taxonomies to be merged.'},
@@ -247,7 +249,11 @@ plugin.methods.register_function(
             'parameter will prepend rank handles whether or not they already '
             'exist in the taxonomy, so should ALWAYS be used in conjunction '
             'with `rank_handle_regex` if rank handles exist in any of the '
-            'inputs.')},
+            'inputs.'),
+        'unclassified_label': 'Specifies what label should be used for '
+                              'taxonomies that could not be resolved (when '
+                              'LCA modes are used).'
+    },
     name='Compare taxonomies and select the longest, highest scoring, or find '
          'the least common ancestor.',
     description='Compare taxonomy annotations and choose the best one. Can '

--- a/rescript/tests/test_merge.py
+++ b/rescript/tests/test_merge.py
@@ -383,7 +383,8 @@ class TestMergeTaxa(TestPluginBase):
                            'Bacillaceae;Bacillus;',
                 '370253':  'Unassigned',
                 '4361279': 'Bacteria;Proteobacteria;'
-                           'Betaproteobacteria;Burkholderiales;Oxalobacteraceae;;',
+                           'Betaproteobacteria;Burkholderiales;'
+                           'Oxalobacteraceae;;',
                 '4369464': 'Bacteria;Proteobacteria;Alphaproteobacteria;'
                            'Rhizobiales;Rhizobiaceae;Rhizobium;leguminosarum',
                 'unique1': 'Bacteria;;;;;;blah',


### PR DESCRIPTION
This PR introduces a fix to replace empty taxonomy strings (resulting from unresolved taxonomies) with 'Unassigned' label to prevent downstream issues with the resulting taxonomy (e.g. the pd.DataFrame -> TSVTaxonomyFormat transformer will turn those into NaN values)  

Closes #111. 