### PR TITLE
update rescript citation to PLoS Comp Bio

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These tutorials demonstrate some of the basic functionality of RESCRIPt, via the
 - [Building a COI database with BOLD sequences](https://forum.qiime2.org/t/building-a-coi-database-from-bold-references/16129)
 - [Building a COI database with NCBI sequences](https://forum.qiime2.org/t/building-a-coi-database-from-ncbi-references/16500)
 
-Examples of visualizations produced by RESCRIPt actions can be found in this [Visualization Gallery](https://forum.qiime2.org/t/processing-filtering-and-evaluating-the-silva-database-and-other-reference-sequence-data-with-rescript/15494#heading--seventeenth-header). 
+Examples of visualizations produced by RESCRIPt actions can be found in this [Visualization Gallery](https://forum.qiime2.org/t/processing-filtering-and-evaluating-the-silva-database-and-other-reference-sequence-data-with-rescript/15494#heading--seventeenth-header).
 
 ## Getting Help
 Problem? Suggestion? Technical errors and user support requests can be filed on the [QIIME 2 Forum](https://forum.qiime2.org/).
@@ -69,7 +69,7 @@ Problem? Suggestion? Technical errors and user support requests can be filed on 
 
 If you use RESCRIPt in your research, please cite the following pre-print:
 
-Michael S Robeson II, Devon R O'Rourke, Benjamin D Kaehler, Michal Ziemski, Matthew R Dillon, Jeffrey T Foster, Nicholas A Bokulich. RESCRIPt: Reproducible sequence taxonomy reference database management for the masses. bioRxiv 2020.10.05.326504; doi: https://doi.org/10.1101/2020.10.05.326504
+Michael S Robeson II, Devon R O'Rourke, Benjamin D Kaehler, Michal Ziemski, Matthew R Dillon, Jeffrey T Foster, Nicholas A Bokulich. (2021) *RESCRIPt: Reproducible sequence taxonomy reference database management*. PLoS Computational Biology 17 (11): e1009581. doi: [10.1371/journal.pcbi.1009581](http://dx.doi.org/10.1371/journal.pcbi.1009581).
 
 
 ## License

--- a/rescript/citations.bib
+++ b/rescript/citations.bib
@@ -1,13 +1,10 @@
-@article {Robeson2020rescript,
+@article {Robeson2021rescript,
 	author = {Robeson, Michael S and O{\textquoteright}Rourke, Devon R and Kaehler, Benjamin D and Ziemski, Michal and Dillon, Matthew R and Foster, Jeffrey T and Bokulich, Nicholas A},
-	title = {RESCRIPt: Reproducible sequence taxonomy reference database management for the masses},
-	elocation-id = {2020.10.05.326504},
-	year = {2020},
-	doi = {10.1101/2020.10.05.326504},
-	publisher = {Cold Spring Harbor Laboratory},
-	URL = {https://www.biorxiv.org/content/early/2020/10/05/2020.10.05.326504},
-	eprint = {https://www.biorxiv.org/content/early/2020/10/05/2020.10.05.326504.full.pdf},
-	journal = {bioRxiv}
+	title = {RESCRIPt: Reproducible sequence taxonomy reference database management},
+	year = {2021},
+	doi = {10.1371/journal.pcbi.1009581},
+	publisher = {PLoS Computational Biology},
+	URL = {http://dx.doi.org/10.1371/journal.pcbi.1009581}
 }
 
 @article{rognes2016vsearch,

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -59,7 +59,7 @@ plugin = Plugin(
     description=('Reference sequence annotation and curation pipeline.'),
     short_description=(
         'Pipeline for reference sequence annotation and curation.'),
-    citations=[citations['Robeson2020rescript']]
+    citations=[citations['Robeson2021rescript']]
 )
 
 


### PR DESCRIPTION
Updates the RESCRIPt citation from the [bioRxiv preprint](https://doi.org/10.1101/2020.10.05.326504), to the recently accepted peer reviewed version at [PLoS Computational Biology](https://doi.org/10.1371/journal.pcbi.1009581).