### PR TITLE
DEP: Fix joblib for ncbi.py

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
 
   run:
     - python {{ python }}
-    - joblib 1.1
     - requests
     - xmltodict
     - pandas {{ pandas }}

--- a/rescript/ncbi.py
+++ b/rescript/ncbi.py
@@ -22,7 +22,7 @@ from skbio import DNA, Protein
 from qiime2 import Metadata
 from collections import OrderedDict
 from joblib import Parallel, delayed
-from joblib.externals.loky.backend.managers import LokyManager
+from multiprocessing import Manager
 
 # This the tool-email pair for this tool that is registered with NCBI.
 # If you change it, register a new tool-email pair with NCBI at
@@ -115,8 +115,7 @@ def _get_ncbi_data(query: str = None, accession_ids: Metadata = None,
                    ranks: list = None, rank_propagation: bool = True,
                    logging_level: str = None, n_jobs: int = 1,
                    db: str = 'nuccore'):
-    manager = LokyManager()
-    manager.start()
+    manager = Manager()
     request_lock = manager.Lock()
 
     if query:


### PR DESCRIPTION
Address issue #143. Specifically, these changes were applied:

- for `ncbi.py`:
  -  The import statement `from joblib.externals.loky.backend.managers import LokyManager` had been replaced with `from multiprocessing import Manager`, along with associated code changes
- for `meta.yaml`:
  - `joblib 1.1` pin was removed