### PR TITLE
MAINT: Add future deprecation warning for orient-seqs

### DIFF
--- a/rescript/orient.py
+++ b/rescript/orient.py
@@ -8,8 +8,17 @@
 
 import tempfile
 from q2_types.feature_data import DNAFASTAFormat, DNAIterator
+from warnings import warn
 
 from ._utilities import run_command
+
+
+def _warn_deprecated(value, default, name):
+    if value != default:
+        warn(
+            f"{name} will be deprecated in a future release.",
+            FutureWarning
+        )
 
 
 def orient_seqs(sequences: DNAFASTAFormat,
@@ -46,6 +55,11 @@ def orient_seqs(sequences: DNAFASTAFormat,
             run_command(cmd)
             with open(out.name, 'r') as orient:
                 orientations = [line.strip() for line in orient]
+
+            # Warn about parameters that will be deprecated
+            _warn_deprecated(perc_identity, 0.9, 'perc_identity')
+            _warn_deprecated(query_cov, 0.9, 'query_cov')
+            _warn_deprecated(left_justify, False, 'left_justify')
 
         # if any query seqs are in reverse orientation, reverse complement
         if '-' in orientations:

--- a/rescript/orient.py
+++ b/rescript/orient.py
@@ -16,7 +16,8 @@ from ._utilities import run_command
 def _warn_deprecated(value, default, name):
     if value != default:
         warn(
-            f"{name} will be deprecated in a future release.",
+            f"{name} is deprecated and will be removed from RESCRIPt 2023.5 "
+            "(RESCRIPt 2023.2 will be the last release with this parameter).",
             FutureWarning
         )
 


### PR DESCRIPTION
This PR adds a future deprecation warning for the parameters `perc_identity`, `query_cov` and `left_justify` in the function `orient-seqs`. See [PR #149](https://github.com/bokulich-lab/RESCRIPt/pull/149) for more details.