### PR TITLE
ENH: get_rdp_data

### DIFF
--- a/rescript/citations.bib
+++ b/rescript/citations.bib
@@ -157,3 +157,17 @@
   pmcid = {PMC7408187},
   pmid = {32761142}
 }
+
+@article{Cole2009,
+  title    = {The Ribosomal Database Project: improved alignments and new tools for {rRNA} analysis},
+  author = {Cole, J R and Wang, Q and Cardenas, E and Fish, J and Chai, B and Farris, R J and Kulam-Syed-Mohideen, A S and McGarrell, D M and Marsh, T and Garrity, G M and Tiedje, J M}, 
+  journal = {Nucleic Acids Res.},
+  volume =  {37},
+  number = {Database issue},
+  pages = {D141--5},
+  month =  jan,
+  year =  {2009},
+  doi = {10.1093/nar/gkn879},
+  pmcid = {PMC2686447},
+  pmid = {19004872}
+}

--- a/rescript/get_rdp_data.py
+++ b/rescript/get_rdp_data.py
@@ -1,0 +1,133 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2022-2022, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import tempfile
+import shutil
+import gzip
+# import warnings
+# import hashlib
+# import pandas as pd
+import qiime2
+from urllib.request import urlretrieve
+# from urllib.error import HTTPError
+# from q2_types.feature_data import MixedCaseDNAFASTAFormat, DNAFASTAFormat
+# from q2_feature_table import merge_seqs, merge_taxa
+
+
+def get_rdp_data(ctx,
+                 ref_db='Archaea+Bacteria',
+                 include_species_labels=False,
+                 rank_propagation=True,
+                 ranks=None):
+
+    parse_taxonomy = ctx.get_action('rescript', 'parse_rdp_taxonomy')
+    merge_rdp_seqs = ctx.get_action('feature_table', 'merge_seqs')
+    merge_rdp_taxonomy = ctx.get_action('feature_table', 'merge_taxa')
+
+    # download data from RDP
+    print('\nDownloading and processing raw files may take some time... '
+          'get some coffee.\n')
+    queries = _assemble_rdp_data_urls(ref_db)
+    rdp_seq_data = _retrieve_data_from_rdp(queries)
+
+    num_seq_files = len(rdp_seq_data)
+
+    if num_seq_files == 2:
+        rdp_tax_df = []
+        rdp_seq_sl = []
+        for rdp_seqs in rdp_seq_data:
+            print('Parsing RDP taxonomy...')
+            taxonomy, = parse_taxonomy(
+                            rdp_reference_sequences=rdp_seqs,
+                            include_species_labels=include_species_labels,
+                            rank_propagation=rank_propagation,
+                            ranks=ranks)
+            # rdp_tax_df.append(taxonomy.view(pd.DataFrame))
+            # rdp_seq_sl.append(rdp_seqs.view(pd.Series))
+            rdp_tax_df.append(taxonomy)
+            rdp_seq_sl.append(rdp_seqs)
+        print('Merging taxonomy ...')
+        merged_rdp_tax, = merge_rdp_taxonomy(data=rdp_tax_df)
+        print('Merging sequences ...')
+        merged_rdp_seqs, = merge_rdp_seqs(data=rdp_seq_sl)
+        print('Writing artifact files...')
+        return merged_rdp_seqs, merged_rdp_tax
+    elif num_seq_files == 1:
+        rdp_seqs = rdp_seq_data[0]
+        rdp_tax, = parse_taxonomy(
+                        rdp_reference_sequences=rdp_seqs,
+                        include_species_labels=include_species_labels,
+                        rank_propagation=rank_propagation,
+                        ranks=ranks)
+        print('Writing artifact files...')
+        return rdp_seqs, rdp_tax
+    elif num_seq_files == 0:
+        raise ValueError('No RDP data to process!')
+    else:
+        raise ValueError('There are more than 2 RDP files! There should '
+                         'be only 1 or 2 files!')
+    # return rdp_seqs, rdp_tax
+
+
+def _assemble_rdp_data_urls(ref_db):
+    '''Generate RDP urls, given database version and reference target.'''
+    # Compile URLs
+    base_url = 'http://rdp.cme.msu.edu/download/'
+
+    if ref_db == 'Archaea+Bacteria':
+        archaea_url = base_url + 'current_Archaea_unaligned.fa.gz'
+        bacteria_url = base_url + 'current_Bacteria_unaligned.fa.gz'
+        return [('archaeal sequences', archaea_url),
+                ('bacterial sequences', bacteria_url)]
+    elif ref_db == 'Fungi':
+        fungi_url = base_url + 'current_Fungi_unaligned.fa.gz'
+        return [('fungal sequences', fungi_url)]
+    else:
+        raise ValueError('Reference database must be either, '
+                         '\'Bacteria+Archaea\' or \'Fungi\'.')
+
+
+def _retrieve_data_from_rdp(queries):
+    '''
+    Download data from RDP, given a list of queries.
+
+    queries: list of tuples of (str, str)
+        (name, urlpath)
+    '''
+    results = []
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        for name, query in queries:
+            print('Retrieving {0} from: {1}'.format(name, query))
+            # grab url
+            destination = os.path.join(tmpdirname, os.path.basename(query))
+            urlretrieve(query, destination)
+
+            # gunzip on demand (RDP releases are gzipped)
+            try:
+                unzipped_destination = os.path.splitext(destination)[0]
+                print('  Unzipping {0}...'.format(name))
+                _gzip_decompress(destination, unzipped_destination)
+                destination = unzipped_destination
+            except OSError:
+                pass
+
+            # import rdp seqs
+            print('Importing RDP sequence data...')
+            results.append(qiime2.Artifact.import_data(
+                                                'FeatureData[Sequence]',
+                                                destination,
+                                                'MixedCaseDNAFASTAFormat'))
+        print(results)
+        return results
+
+
+def _gzip_decompress(input_fp, output_fp):
+    with gzip.open(input_fp, 'rt') as temp_in:
+        with open(output_fp, 'w') as temp_out:
+            shutil.copyfileobj(temp_in, temp_out)

--- a/rescript/parse_rdp.py
+++ b/rescript/parse_rdp.py
@@ -1,0 +1,89 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2021, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import pandas as pd
+from collections import OrderedDict, defaultdict
+from q2_types.feature_data import DNAIterator
+from .parse_silva_taxonomy import _keep_allowed_chars
+
+
+ALLOWED_RDP_RANKS = OrderedDict({'rootrank': 'root__', 'domain': 'd__',
+                                 'phylum': 'p__', 'class': 'c__',
+                                 'subclass': 'cs__', 'order': 'o__',
+                                 'suborder': 'os__', 'family': 'f__',
+                                 'genus': 'g__'})
+
+DEFAULT_RDP_RANKS = ['domain', 'phylum', 'class', 'subclass', 'order',
+                     'suborder', 'family', 'genus']
+
+
+def parse_rdp_taxonomy(rdp_reference_sequences: DNAIterator,
+                       rank_propagation: bool = True, ranks: list = None,
+                       include_species_labels: bool = False) -> pd.Series:
+
+    sp_label_dict = defaultdict()
+    taxd = defaultdict()
+    for seq in rdp_reference_sequences:
+        # parse taxonomy
+        seq_id = seq.metadata['id']
+        sp_label, tax_data = seq.metadata['description'].split(
+                                'Lineage=')
+        new_sp_label = _keep_allowed_chars(
+                                        "_".join(sp_label.strip().split()[:2]))
+        sp_label_dict[seq_id] = new_sp_label
+
+        known_lineage = tax_data.replace('"', '').rsplit(';')
+        if tax_data.endswith(';'):
+            known_lineage = known_lineage[:-1]
+
+        taxd[seq_id] = dict(
+                            [(x[1], x[0]) for x in zip(
+                                known_lineage[0::2], known_lineage[1::2])])
+
+    # make dataframe with ranks as column labels.
+    df = pd.DataFrame.from_dict(taxd, orient='index',
+                                columns=DEFAULT_RDP_RANKS)
+
+    # propagate ranks (or not), fillna, and append prefixes
+    if rank_propagation:
+        df.ffill(axis=1, inplace=True)
+
+    # rename columns with prefixes
+    df.rename(columns=ALLOWED_RDP_RANKS, inplace=True)
+
+    # In case we decide NOT to ffill. We'll need an empty string, so
+    # that we can have empty prefixes (e.g. 'p__') appear in our
+    # taxonomy file.Otherwise these will be empty cells in the
+    # dataframe.
+    df.fillna('', inplace=True)
+    # use default ranks if no rank list supplied
+    if ranks is None:
+        ranks = DEFAULT_RDP_RANKS
+
+    # Sort user ranks relative to allowed_ranks
+    # this ensures that the taxonomic ranks supplied by the user
+    # are in order
+    sorted_ranks = [p for r, p in ALLOWED_RDP_RANKS.items()
+                    if r in ranks]
+
+    # If we wish to include species labels we need to add to the sorted_ranks
+    # and the dataframe.
+    if include_species_labels:
+        sorted_ranks.append('s__')
+        df.loc[:, 's__'] = df.index.map(sp_label_dict)
+
+    # add prefixes to selected ranks
+    df.loc[:, sorted_ranks] = \
+        df.loc[:, sorted_ranks].apply(lambda x: x.name + x)
+
+    # subset dataframe based on user-selected ranks
+    rdp_taxonomy = df.loc[:, sorted_ranks].agg('; '.join, axis=1)
+    rdp_taxonomy.index.name = 'Feature ID'
+    rdp_taxonomy.rename('Taxon', inplace=True)
+
+    return rdp_taxonomy


### PR DESCRIPTION
Even though there is an avenue for QIIME 2 users to [obtain and import premade RDP files](https://forum.qiime2.org/t/importing-sequence-data-with-lower-case-nucleotide-characters-constructing-an-rdp-classifier-as-an-example/25158) for use in taxonomy assignment. Some users may like to curate the RDP database themselves. This code will provide that ability, while also extracting additional taxonomic rank information not currently available from the premade QIIME 2 compatible RDP files.

The full RDP data is available [here](http://rdp.cme.msu.edu/misc/resources.jsp), and contains the latest information as per the [08/14/2020 RDP release notes](http://rdp.cme.msu.edu/misc/rel10info.jsp).

Currently this draft includes:

- two actions:
  - `parse-rdp-taxonomy`
    - optionally add species labels (*e.g.* like `get-silva-data`)
    - optionally propagate taxonomic ranks
    - choose ranks of interest
  - `get-rdp-data`
    - wraps  `parse-rdp-taxonomy` under the hood
    - downloads both Archaea and Bacteria (16S rRNA gene data) together
    - downloads Fungi (28S rRNA gene data)


**TODO:**
- [ ] add ability to download the Archaea and Bacteria domains individually
- [ ] add ability to download aligned sequences
- [ ] write test code
- [ ] consider refactoring the `get_rdp_data` function and associated code to resemble `get_gtdb_data`