### PR TITLE
Update ci-dev.yaml

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -9,4 +9,4 @@ jobs:
   ci:
     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
     with:
-      distro: core
+      distro: shotgun


### PR DESCRIPTION
We missed the fact that this has a dependency on q2-types-genomics, so putting it in the shotgun distribution for the moment.

Also, would it be possible to request push access to this repo?

(I need the a manual trigger of [this action](https://github.com/bokulich-lab/RESCRIPt/actions/workflows/join-release.yaml) to run to get this into the 2023.9 release).