### PR TITLE
DEP: drop q2-longitudinal

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -27,7 +27,6 @@ requirements:
     - scikit-bio {{ scikit_bio }}
     - q2-types {{ qiime2_epoch }}.*
     - q2-types-genomics >2023.2
-    - q2-longitudinal {{ qiime2_epoch }}.*
     - q2-feature-classifier {{ qiime2_epoch }}.*
     - qiime2 {{ qiime2_epoch }}.*
 


### PR DESCRIPTION
Turns out this is causing some issues with conda and matplotlib that don't really _need_ to be an issue right now.

https://github.com/qiime2/distributions/actions/runs/6385353574/job/17331623684?pr=27

This isn't an issue with the amplicon distro for whatever reason, but we haven't looked into it too closely yet.

Related to #163 