### PR TITLE
DOC: fixes citation formatting reqs for sphinx docs builds

### DIFF
--- a/rescript/citations.bib
+++ b/rescript/citations.bib
@@ -1,7 +1,8 @@
 @article {Robeson2021rescript,
 	author = {Robeson, Michael S and O{\textquoteright}Rourke, Devon R and Kaehler, Benjamin D and Ziemski, Michal and Dillon, Matthew R and Foster, Jeffrey T and Bokulich, Nicholas A},
 	title = {RESCRIPt: Reproducible sequence taxonomy reference database management},
-	year = {2021},
+	journal = {PLoS Computational Biology},
+  year = {2021},
 	doi = {10.1371/journal.pcbi.1009581},
 	publisher = {PLoS Computational Biology},
 	URL = {http://dx.doi.org/10.1371/journal.pcbi.1009581}
@@ -66,6 +67,7 @@
 
 @article{ncbi2018database,
   title={Database resources of the national center for biotechnology information},
+  author={NCBI Resource Coordinators},
   journal={Nucleic acids research},
   volume={46},
   number={D1},

--- a/rescript/citations.bib
+++ b/rescript/citations.bib
@@ -1,11 +1,11 @@
 @article {Robeson2021rescript,
-	author = {Robeson, Michael S and O{\textquoteright}Rourke, Devon R and Kaehler, Benjamin D and Ziemski, Michal and Dillon, Matthew R and Foster, Jeffrey T and Bokulich, Nicholas A},
-	title = {RESCRIPt: Reproducible sequence taxonomy reference database management},
-	journal = {PLoS Computational Biology},
+  author = {Robeson, Michael S and O{\textquoteright}Rourke, Devon R and Kaehler, Benjamin D and Ziemski, Michal and Dillon, Matthew R and Foster, Jeffrey T and Bokulich, Nicholas A},
+  title = {RESCRIPt: Reproducible sequence taxonomy reference database management},
+  journal = {PLoS Computational Biology},
   year = {2021},
-	doi = {10.1371/journal.pcbi.1009581},
-	publisher = {PLoS Computational Biology},
-	URL = {http://dx.doi.org/10.1371/journal.pcbi.1009581}
+  doi = {10.1371/journal.pcbi.1009581},
+  publisher = {Public Library of Science},
+  url = {http://dx.doi.org/10.1371/journal.pcbi.1009581}
 }
 
 @article{rognes2016vsearch,
@@ -74,6 +74,8 @@
   pages={D8--D13},
   year={2018},
   publisher={Oxford University Press}
+  doi = {10.1093/nar/gkx1095},
+  url = {https://doi.org/10.1093/nar/gkx1095},
 }
 
 @article{benson2012genbank,


### PR DESCRIPTION
I had to update these citations to meet the Sphinx build requirements in order to get our docs build working with RESCRIPt in the amplicon distro.

Here are the papers I referenced when making these changes:
https://academic.oup.com/nar/article/46/D1/D8/4621330#authorNotesSectionTitle
https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1009581