### PR TITLE
ENH: Adds ability to fetch GTDB v220 to get-gtdb-data

### DIFF
--- a/rescript/get_gtdb.py
+++ b/rescript/get_gtdb.py
@@ -55,6 +55,12 @@ def _assemble_queries(version='220.0',
     # ^^ Set `base_version` variable becuase number after the decimal is
     # only used for the directory. GTDB trims this off for the actual
     # file names...
+    # GTDB v220 started storing the ssu_reps FASTA files
+    # as 'fna.gz' instead of their usual 'tar.gz'.
+    if version == '220.0':
+        stype = 'fna'
+    else:
+        stype = 'tar'
 
     if db_type == 'SpeciesReps':
         ver_dom_dict = defaultdict(lambda: defaultdict(dict))
@@ -64,36 +70,28 @@ def _assemble_queries(version='220.0',
         else:
             ver_dom_dict[version][domain] = VERSION_MAP_DICT[version][domain]
 
-        # GTDB v220 started storing the ssu_reps FASTA files
-        # as 'fna.gz' instead of their usual 'tar.gz'.
-        if version == '220.0':
-            full_url = (base_url + 'release{bver}/{ver}/genomic_files_reps/'
-                        '{cp}_ssu_reps_r{bver}.fna.gz')
-        else:
-            full_url = (base_url + 'release{bver}/{ver}/genomic_files_reps/'
-                        '{cp}_ssu_reps_r{bver}.tar.gz')
+        full_url = (base_url + 'release{bver}/{ver}/genomic_files_reps/'
+                    '{cp}_ssu_reps_r{bver}.{stype}.gz')
 
         for version, dcp in ver_dom_dict.items():
             for dom, cp in dcp.items():
                 queries.append((dom,
                                 full_url.format(**{'ver': version,
                                                    'bver': base_version,
-                                                   'cp': cp})))
+                                                   'cp': cp,
+                                                   'stype': stype})))
     elif db_type == 'All':
         # Note: GTDB does not maintain separate 'Bacteria' and
         # 'Archaea' files for 'All'. This is only done for
         # the 'SpeciesReps'. Again, account for filename changes
-        # to 'fna.gz' in v220.
-        if version == '220.0':
-            full_url = (base_url + 'release{bver}/{ver}/genomic_files_all/'
-                        'ssu_all_r{bver}.fna.gz')
-        else:
-            full_url = (base_url + 'release{bver}/{ver}/genomic_files_all/'
-                        'ssu_all_r{bver}.tar.gz')
+        # to 'fna.gz' in v220, i.e. 'stype'.
+        full_url = (base_url + 'release{bver}/{ver}/genomic_files_all/'
+                    'ssu_all_r{bver}.{stype}.gz')
 
         queries.append((db_type,
                         full_url.format(**{'ver': version,
-                                           'bver': base_version})))
+                                           'bver': base_version,
+                                           'stype': stype})))
     return queries
 
 

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -953,7 +953,8 @@ plugin.methods.register_function(
     function=get_gtdb_data,
     inputs={},
     parameters={
-        'version': Str % Choices(['202.0', '207.0', '214.0', '214.1']),
+        'version': Str % Choices(['202.0', '207.0', '214.0', '214.1',
+                                  '220.0']),
         'domain': Str % Choices(['Both', 'Bacteria', 'Archaea']),
         'db_type': Str % Choices(['All', 'SpeciesReps'])
         },

--- a/rescript/tests/test_get_gtdb.py
+++ b/rescript/tests/test_get_gtdb.py
@@ -55,17 +55,19 @@ class TestGetGTDB(TestPluginBase):
 
     # test that appropriate URLs are assembled
     def test_assemble_species_rep_queries(self):
-        obs_query_urls = _assemble_queries('214.1', 'SpeciesReps', 'Both')
+        # checking v220 as GTDB updated the file format for the "ssu_rep"
+        # FASTA files to 'fna.gz' from their usual 'tar.gz'.
+        obs_query_urls = _assemble_queries('220.0', 'SpeciesReps', 'Both')
         print('obs queries: ', obs_query_urls)
 
         exp_query_urls = [('Archaea',
                            'https://data.gtdb.ecogenomic.org/releases/'
-                           'release214/214.1/genomic_files_reps/'
-                           'ar53_ssu_reps_r214.tar.gz'),
+                           'release220/220.0/genomic_files_reps/'
+                           'ar53_ssu_reps_r220.fna.gz'),
                           ('Bacteria',
                            'https://data.gtdb.ecogenomic.org/releases/'
-                           'release214/214.1/genomic_files_reps/'
-                           'bac120_ssu_reps_r214.tar.gz')]
+                           'release220/220.0/genomic_files_reps/'
+                           'bac120_ssu_reps_r220.fna.gz')]
         print('exp queries: ', exp_query_urls)
         self.assertEqual(obs_query_urls, exp_query_urls)
 


### PR DESCRIPTION
Resolves issue #183.

Also includes a refactor of some code... That is, GTDB v220 now hosts the FASTA files as `fna.gz`, while files for the older versions of the database continue to be hosted as `tar.gz`.