### PR TITLE
CI: adds command to run tests

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -40,6 +40,9 @@ test:
     - rescript
     - qiime2.plugins.rescript
 
+  commands:
+    - py.test --pyargs rescript
+
 about:
   home: https://github.com/bokulich-lab/RESCRIPt
   license: BSD-3-Clause


### PR DESCRIPTION
this needs to be added so that the unit test suite actually runs for all CI actions (ci-dev, prepare, release, etc)