### PR TITLE
TEMPFIX: skip unit tests that rely on q2-longitudinal if it is not installed

### DIFF
--- a/rescript/tests/test_cross_validate.py
+++ b/rescript/tests/test_cross_validate.py
@@ -21,7 +21,7 @@ from rescript import cross_validate
 import_data = qiime2.Artifact.import_data
 
 try:
-    from qiime2.plugins import longitudinal
+    from qiime2.plugins import longitudinal # noqa
     import_q2l = True
 except ImportError:
     import_q2l = False

--- a/rescript/tests/test_cross_validate.py
+++ b/rescript/tests/test_cross_validate.py
@@ -13,13 +13,21 @@ from qiime2.plugins import rescript
 import qiime2
 import pandas as pd
 import pandas.testing as pdt
+import pytest
 
 from rescript import cross_validate
 
 
 import_data = qiime2.Artifact.import_data
 
+try:
+    from qiime2.plugins import longitudinal
+    import_q2l = True
+except ImportError:
+    import_q2l = False
 
+
+@pytest.mark.skipif(not import_q2l, reason="requires q2-longitudinal")
 class TestPipelines(TestPluginBase):
     package = 'rescript.tests'
 

--- a/rescript/tests/test_evaluate.py
+++ b/rescript/tests/test_evaluate.py
@@ -21,7 +21,7 @@ from rescript import evaluate
 import_data = qiime2.Artifact.import_data
 
 try:
-    from qiime2.plugins import longitudinal
+    from qiime2.plugins import longitudinal # noqa
     import_q2l = True
 except ImportError:
     import_q2l = False

--- a/rescript/tests/test_evaluate.py
+++ b/rescript/tests/test_evaluate.py
@@ -13,11 +13,18 @@ import pandas as pd
 import numpy as np
 import pandas.testing as pdt
 from q2_types.feature_data import DNAIterator
+import pytest
 
 from rescript import evaluate
 
 
 import_data = qiime2.Artifact.import_data
+
+try:
+    from qiime2.plugins import longitudinal
+    import_q2l = True
+except ImportError:
+    import_q2l = False
 
 
 class TestEvaluateUtilities(TestPluginBase):
@@ -56,7 +63,9 @@ class TestEvaluateTaxonomy(TestPluginBase):
         self.taxa = import_data(
             'FeatureData[Taxonomy]', self.get_data_path('derep-taxa.tsv'))
 
-    # this just tests that the pipeline runs, other tests test proper function
+    # This just tests that the pipeline runs, other tests test proper function.
+    # We skip this if q2-longitudinal is not installed.
+    @pytest.mark.skipif(not import_q2l, reason="requires q2-longitudinal")
     def test_pipeline(self):
         rescript.actions.evaluate_taxonomy([self.taxa], ["name"], "")
 


### PR DESCRIPTION
This is only temporary, until we finish replacing the q2-longitudinal dependency with q2-visard.

We will skip tests that rely on q2-longitudinal if q2-longitudinal is not installed in the environment.