### PR TITLE
ENH: Adds SILVA 138.2

### DIFF
--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -20,7 +20,7 @@ from q2_types.feature_data import RNAFASTAFormat
 
 
 def get_silva_data(ctx,
-                   version='138.1',
+                   version='138.2',
                    target='SSURef_NR99',
                    include_species_labels=False,
                    rank_propagation=True,
@@ -86,7 +86,7 @@ def _assemble_silva_data_urls(version, target, download_sequences=True):
     tax_url = base_url_tax + '.txt'
 
     # add ".gz" for the following versions:
-    if version in ['138', '138.1']:
+    if version in ['138', '138.1', '138.2']:
         tree_url += '.gz'
         tax_url += '.gz'
 

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -729,7 +729,7 @@ RANK_DESCRIPTION = ('List of taxonomic ranks for building a taxonomy from the '
                     "[default: '" +
                     "', '".join(DEFAULT_RANKS) + "']")
 
-_SILVA_VERSIONS = ['128', '132', '138', '138.1']
+_SILVA_VERSIONS = ['128', '132', '138', '138.1', '138.2']
 _SILVA_TARGETS = ['SSURef_NR99', 'SSURef', 'LSURef_NR99', 'LSURef']
 
 version_map, target_map, _ = TypeMap({
@@ -737,7 +737,7 @@ version_map, target_map, _ = TypeMap({
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef')): Visualization,
     (Str % Choices('138'),
      Str % Choices('SSURef_NR99', 'SSURef')): Visualization,
-    (Str % Choices('138.1'),
+    (Str % Choices('138.1', '138.2'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef_NR99',
                    'LSURef')): Visualization,
 })


### PR DESCRIPTION
Addresses #196 

SILVA recently put out a [maintenance release centering on taxonomy](https://www.arb-silva.de/news/view/2024/07/11/silva-release-1382/). This constitutes [version 132](https://www.arb-silva.de/no_cache/download/archive/release_138_2/).

I've added the ability to automatically download both the SSU and LSU files within `get-silva-data`.