### PR TITLE
ENH: Adds NCBI api-key option

### DIFF
--- a/rescript/ncbi.py
+++ b/rescript/ncbi.py
@@ -82,7 +82,7 @@ def get_ncbi_data(
         raise ValueError('Query or accession_ids must be supplied')
     if api_key:
         try:
-            (api_key,) = api_key.get_ids()
+            api_key, = api_key.get_ids()
             _entrez_params['api_key'] = api_key
             global _entrez_delay
             _entrez_delay = 0.1
@@ -111,7 +111,7 @@ def get_ncbi_data_protein(
         raise ValueError('Query or accession_ids must be supplied')
     if api_key:
         try:
-            (api_key,) = api_key.get_ids()
+            api_key, = api_key.get_ids()
             _entrez_params['api_key'] = api_key
             global _entrez_delay
             _entrez_delay = 0.1

--- a/rescript/ncbi.py
+++ b/rescript/ncbi.py
@@ -74,16 +74,20 @@ def get_ncbi_data(
         query: str = None, accession_ids: Metadata = None,
         ranks: list = None, rank_propagation: bool = True,
         logging_level: str = None, n_jobs: int = 1,
-        api_key: str = None
+        api_key: Metadata = None
 ) -> (DNAIterator, DataFrame):
     if ranks is None:
         ranks = _default_ranks
     if query is None and accession_ids is None:
         raise ValueError('Query or accession_ids must be supplied')
     if api_key:
-        _entrez_params['api_key'] = api_key
-        global _entrez_delay
-        _entrez_delay = 0.1
+        try:
+            (api_key,) = api_key.get_ids()
+            _entrez_params['api_key'] = api_key
+            global _entrez_delay
+            _entrez_delay = 0.1
+        except ValueError:
+            raise ValueError("API KEY file should contain only one value!")
 
     seqs, taxa = _get_ncbi_data(query, accession_ids, ranks, rank_propagation,
                                 logging_level, n_jobs, 'nuccore')
@@ -99,16 +103,20 @@ def get_ncbi_data_protein(
         query: str = None, accession_ids: Metadata = None,
         ranks: list = None, rank_propagation: bool = True,
         logging_level: str = None, n_jobs: int = 1,
-        api_key: str = None
+        api_key: Metadata = None
         ) -> (ProteinIterator, DataFrame):
     if ranks is None:
         ranks = _default_ranks
     if query is None and accession_ids is None:
         raise ValueError('Query or accession_ids must be supplied')
     if api_key:
-        _entrez_params['api_key'] = api_key
-        global _entrez_delay
-        _entrez_delay = 0.1
+        try:
+            (api_key,) = api_key.get_ids()
+            _entrez_params['api_key'] = api_key
+            global _entrez_delay
+            _entrez_delay = 0.1
+        except ValueError:
+            raise ValueError("API KEY file should contain only one value!")
 
     seqs, taxa = _get_ncbi_data(query, accession_ids, ranks, rank_propagation,
                                 logging_level, n_jobs, 'protein')

--- a/rescript/ncbi.py
+++ b/rescript/ncbi.py
@@ -82,6 +82,8 @@ def get_ncbi_data(
         raise ValueError('Query or accession_ids must be supplied')
     if api_key:
         _entrez_params['api_key'] = api_key
+        global _entrez_delay
+        _entrez_delay = 0.1
 
     seqs, taxa = _get_ncbi_data(query, accession_ids, ranks, rank_propagation,
                                 logging_level, n_jobs, 'nuccore')
@@ -105,6 +107,8 @@ def get_ncbi_data_protein(
         raise ValueError('Query or accession_ids must be supplied')
     if api_key:
         _entrez_params['api_key'] = api_key
+        global _entrez_delay
+        _entrez_delay = 0.1
 
     seqs, taxa = _get_ncbi_data(query, accession_ids, ranks, rank_propagation,
                                 logging_level, n_jobs, 'protein')
@@ -221,6 +225,7 @@ def _epost(params, ids, request_lock, logging_level, entrez_delay=0.334):
                 epost, data=data, params=_entrez_params, timeout=10,
                 stream=True)
             print('\nRequesting the following epost url: ', r.url)
+            print('With a delay of ', entrez_delay, ' seconds.')
         finally:
             request_lock.release()
             logger.debug('request lock released')
@@ -248,6 +253,7 @@ def _esearch(params, logging_level, entrez_delay=0.334):
         time.sleep(entrez_delay)
         r = requests.get(esearch, params=params, timeout=10)
         print('\nRequesting the following esearch url: ', r.url)
+        print('With a delay of ', entrez_delay, ' seconds.')
         r.raise_for_status()
         webenv = parse(r.content)['eSearchResult']
         if 'WebEnv' not in webenv:
@@ -274,6 +280,7 @@ def _efetch_5000(params, request_lock, logging_level, entrez_delay=0.334):
         try:
             r = requests.get(efetch, params=params, timeout=10, stream=True)
             print('\nRequesting the following efetch url: ', r.url)
+            print('With a delay of ', entrez_delay, ' seconds.')
         finally:
             request_lock.release()
             logger.debug('request lock released')

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -869,7 +869,8 @@ GET_NCBI_DATA_PARAMS = {
     'rank_propagation': Bool,
     'logging_level': Str % Choices([
         'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),
-    'n_jobs': Int % Range(1, None)
+    'n_jobs': Int % Range(1, None),
+    'api_key': Str
 }
 GET_NCBI_DATA_PARAM_DESCRIPTIONS_COMMON = {
     'ranks': 'List of taxonomic ranks for building a taxonomy from the '
@@ -879,7 +880,10 @@ GET_NCBI_DATA_PARAM_DESCRIPTIONS_COMMON = {
     'logging_level': 'Logging level, set to INFO for download progress or '
                         'DEBUG for copious verbosity',
     'n_jobs': 'Number of concurrent download connections. More is faster '
-              'until you run out of bandwidth.'
+              'until you run out of bandwidth.',
+    'api_key': 'NCBI API Key that increases requests/second from 3 to 10. '
+               'See: '
+               'https://support.nlm.nih.gov/knowledgebase/article/KA-05317/.'
 }
 GET_NCBI_DATA_PARAM_DESCRIPTIONS_DNA = {
         'query': 'Query on the NCBI Nucleotide database',

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -870,7 +870,7 @@ GET_NCBI_DATA_PARAMS = {
     'logging_level': Str % Choices([
         'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']),
     'n_jobs': Int % Range(1, None),
-    'api_key': Str
+    'api_key': Metadata
 }
 GET_NCBI_DATA_PARAM_DESCRIPTIONS_COMMON = {
     'ranks': 'List of taxonomic ranks for building a taxonomy from the '
@@ -881,7 +881,8 @@ GET_NCBI_DATA_PARAM_DESCRIPTIONS_COMMON = {
                         'DEBUG for copious verbosity',
     'n_jobs': 'Number of concurrent download connections. More is faster '
               'until you run out of bandwidth.',
-    'api_key': 'NCBI API Key that increases requests/second from 3 to 10. '
+    'api_key': 'Metadata file that contains the NCBI API Key. This will '
+               'increases requests/second from 3 to 10. '
                'See: '
                'https://support.nlm.nih.gov/knowledgebase/article/KA-05317/.'
 }


### PR DESCRIPTION
Attempts to fix  #145, by adding the `--p-api-key` option to both `get-ncbi-data` and `get-ncbi-data-protein`. It does this by appending `api_key` to the `_entrez_params` dictionary so that it is available for all NCBI requests.

To do:

- Test code
  - I could use help on the best way to write test code for this...
  - Might test reading in a mock api-key?

