### PR TITLE
IMP: replace volatility with lineplot for `evaluate_*` visualizers

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -33,6 +33,7 @@ test:
   requires:
     - pytest
     - q2-types >={{ q2_types }}
+    - q2-vizard >={{ q2_vizard }}
     - q2-longitudinal >={{ q2_longitudinal }}
     - q2-feature-classifier >={{ q2_feature_classifier }}
     - qiime2 >={{ qiime2 }}

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -34,7 +34,6 @@ test:
     - pytest
     - q2-types >={{ q2_types }}
     - q2-vizard >={{ q2_vizard }}
-    - q2-longitudinal >={{ q2_longitudinal }}
     - q2-feature-classifier >={{ q2_feature_classifier }}
     - qiime2 >={{ qiime2 }}
 

--- a/rescript/cross_validate.py
+++ b/rescript/cross_validate.py
@@ -162,11 +162,9 @@ def _split_fasta(sequences, train_ids, test_ids):
     return train_seqs, test_seqs
 
 
-def evaluate_classifications(ctx,
-                             expected_taxonomies,
-                             observed_taxonomies,
-                             labels=None):
-    lineplot = ctx.get_action('vizard', 'lineplot')
+def _evaluate_classifications_stats(expected_taxonomies,
+                                    observed_taxonomies,
+                                    labels=None):
     # Validate inputs.
     if len(expected_taxonomies) != len(observed_taxonomies):
         raise ValueError('Expected and Observed Taxonomies do not match. '
@@ -201,7 +199,22 @@ def evaluate_classifications(ctx,
     # convert index to strings
     precision_recall.index = pd.Index(
         [str(i) for i in range(1, len(precision_recall.index) + 1)], name='id')
-    plots, = lineplot(metadata=q2.Metadata(precision_recall),
+
+    return q2.Metadata(precision_recall)
+
+
+def evaluate_classifications(ctx,
+                             expected_taxonomies,
+                             observed_taxonomies,
+                             labels=None):
+    lineplot = ctx.get_action('vizard', 'lineplot')
+
+    md = _evaluate_classifications_stats(
+        expected_taxonomies=expected_taxonomies,
+        observed_taxonomies=observed_taxonomies,
+        labels=labels)
+
+    plots, = lineplot(metadata=md,
                       x_measure='Level',
                       y_measure='F-Measure',
                       group_by='Dataset',

--- a/rescript/cross_validate.py
+++ b/rescript/cross_validate.py
@@ -166,7 +166,7 @@ def evaluate_classifications(ctx,
                              expected_taxonomies,
                              observed_taxonomies,
                              labels=None):
-    volatility = ctx.get_action('longitudinal', 'volatility')
+    lineplot = ctx.get_action('vizard', 'lineplot')
     # Validate inputs.
     if len(expected_taxonomies) != len(observed_taxonomies):
         raise ValueError('Expected and Observed Taxonomies do not match. '
@@ -201,10 +201,11 @@ def evaluate_classifications(ctx,
     # convert index to strings
     precision_recall.index = pd.Index(
         [str(i) for i in range(1, len(precision_recall.index) + 1)], name='id')
-    plots, = volatility(metadata=q2.Metadata(precision_recall),
-                        state_column='Level',
-                        default_group_column='Dataset',
-                        default_metric='F-Measure')
+    plots, = lineplot(metadata=q2.Metadata(precision_recall),
+                      x_measure='Level',
+                      y_measure='F-Measure',
+                      group_by='Dataset',
+                      title='RESCRIPt Evaluate Classifications')
     return plots
 
 

--- a/rescript/evaluate.py
+++ b/rescript/evaluate.py
@@ -48,11 +48,13 @@ def evaluate_taxonomy(ctx,
     results.index = pd.Index(
         [str(i) for i in range(1, len(results.index) + 1)], name='id')
     results = q2.Metadata(results)
-    volatility = ctx.get_action('longitudinal', 'volatility')
-    plots, = volatility(metadata=results,
-                        state_column='Level',
-                        default_group_column='Dataset',
-                        default_metric='Taxonomic Entropy')
+    raise ValueError(results)
+    lineplot = ctx.get_action('vizard', 'lineplot')
+    plots, = lineplot(metadata=results,
+                      x_measure='Level',
+                      y_measure='Metric Column',
+                      group_by='Dataset',
+                      title='Taxonomic Entropy')
     return plots
 
 

--- a/rescript/evaluate.py
+++ b/rescript/evaluate.py
@@ -48,13 +48,13 @@ def evaluate_taxonomy(ctx,
     results.index = pd.Index(
         [str(i) for i in range(1, len(results.index) + 1)], name='id')
     results = q2.Metadata(results)
-    raise ValueError(results)
+
     lineplot = ctx.get_action('vizard', 'lineplot')
     plots, = lineplot(metadata=results,
                       x_measure='Level',
-                      y_measure='Metric Column',
+                      y_measure='Taxonomic Entropy',
                       group_by='Dataset',
-                      title='Taxonomic Entropy')
+                      title='RESCRIPt Evaluate Taxonomy')
     return plots
 
 

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -82,7 +82,7 @@ UNITE_LICENSE_NOTE = (
     'CC BY-SA 4.0. To learn more, please visit https://unite.ut.ee/cite.php '
     'and https://creativecommons.org/licenses/by-sa/4.0/.')
 
-VOLATILITY_PLOT_XAXIS_INTERPRETATION = (
+LINEPLOT_XAXIS_INTERPRETATION = (
     'The x-axis in these plots represents the taxonomic '
     'levels present in the input taxonomies so are labeled numerically '
     'instead of by rank, but typically for 7-level taxonomies these will '
@@ -225,7 +225,7 @@ plugin.pipelines.register_function(
         'sets of true taxonomic labels to the predicted taxonomies for the '
         'same set(s) of features. Output an interactive line plot of '
         'classification accuracy for each pair of expected/observed '
-        'taxonomies. ' + VOLATILITY_PLOT_XAXIS_INTERPRETATION),
+        'taxonomies. ' + LINEPLOT_XAXIS_INTERPRETATION),
     citations=[citations['bokulich2018optimizing'],
                citations['bokulich2017q2']]
 )
@@ -395,7 +395,7 @@ plugin.pipelines.register_function(
         'unique labels, taxonomic entropy, and the number of features that '
         'are (un)classified at each taxonomic level. This action is useful '
         'for both reference taxonomies and classification results. ' +
-        VOLATILITY_PLOT_XAXIS_INTERPRETATION),
+        LINEPLOT_XAXIS_INTERPRETATION),
     citations=[citations['bokulich2017q2']]
 )
 


### PR DESCRIPTION
Closes https://github.com/qiime2/q2-vizard/issues/32

This PR will replace the use of `longitudinal volatility` with the new lineplot that's now available within q2-vizard. The following visualizers will receive this replacement:

- evaluate-classifications
- evaluate-taxonomy
