### PR TITLE
TEST: fixes test failure due to updated GH runner log formatting

### DIFF
--- a/rescript/tests/test_ncbi.py
+++ b/rescript/tests/test_ncbi.py
@@ -237,7 +237,7 @@ class TestNCBI(TestPluginBase):
                     'k__Fungi; p__Basidiomycota; c__Agaricomycetes; '
                     'o__Boletales; f__Boletaceae; g__Boletus; s__edulis'
                 )
-            self.assertTrue('Retrying' in log.output[0])
+            self.assertTrue('Retrying' in '\n'.join(log.output[:3]))
 
     def test_get_ncbi_dirty_tricks(self):
         with self.assertLogs(level='WARNING') as log:


### PR DESCRIPTION
Addresses the latest [amplicon prepare failure](https://github.com/qiime2/distributions/actions/runs/11197922773/job/31251433278?pr=406#step:9:208) due to an apparent change in the GH runner's log formatting. `Retrying` is now present on the third line of the log, instead of the first line.