### PR TITLE
ENH: updating version number with release date

### DIFF
--- a/rescript/get_unite.py
+++ b/rescript/get_unite.py
@@ -20,17 +20,18 @@ from q2_types.feature_data import (
 
 # Source: https://unite.ut.ee/repository.php
 UNITE_DOIS = {
-    "10.0": {
+    # Old version 10.0 is not listed here
+    "2025-02-19": {
         "fungi": {
-            False: "10.15156/BIO/2959336",
-            True: "10.15156/BIO/2959337",
+            False: "10.15156/BIO/3301241",
+            True: "10.15156/BIO/3301242",
         },
         "eukaryotes": {
-            False: "10.15156/BIO/2959338",
-            True: "10.15156/BIO/2959339",
+            False: "10.15156/BIO/3301243",
+            True: "10.15156/BIO/3301244",
         },
     },
-    "9.0": {
+    "2023-07-18": {
         "fungi": {
             False: "10.15156/BIO/2938079",
             True: "10.15156/BIO/2938080",
@@ -41,7 +42,7 @@ UNITE_DOIS = {
         },
     },
     # Old version 9.0 is not listed here
-    "8.3": {
+    "2021-05-10": {
         "fungi": {
             False: "10.15156/BIO/1264708",
             True: "10.15156/BIO/1264763",
@@ -51,7 +52,7 @@ UNITE_DOIS = {
             True: "10.15156/BIO/1264861",
         },
     },
-    "8.2": {
+    "2020-02-20": {
         "fungi": {
             False: "10.15156/BIO/786385",
             True: "10.15156/BIO/786387",
@@ -155,7 +156,7 @@ def _unite_get_artifacts(
 
 
 def get_unite_data(
-    version: str = "10.0",
+    version: str = "2025-02-19",
     taxon_group: str = "eukaryotes",
     cluster_id: str = "99",
     singletons: bool = False,

--- a/rescript/get_unite.py
+++ b/rescript/get_unite.py
@@ -20,7 +20,6 @@ from q2_types.feature_data import (
 
 # Source: https://unite.ut.ee/repository.php
 UNITE_DOIS = {
-    # Old version 10.0 is not listed here
     "2025-02-19": {
         "fungi": {
             False: "10.15156/BIO/3301241",
@@ -29,6 +28,16 @@ UNITE_DOIS = {
         "eukaryotes": {
             False: "10.15156/BIO/3301243",
             True: "10.15156/BIO/3301244",
+        },
+    },
+    "2024-04-04": {
+        "fungi": {
+            False: "10.15156/BIO/2959336",
+            True: "10.15156/BIO/2959337",
+        },
+        "eukaryotes": {
+            False: "10.15156/BIO/2959338",
+            True: "10.15156/BIO/2959339",
         },
     },
     "2023-07-18": {

--- a/rescript/get_unite.py
+++ b/rescript/get_unite.py
@@ -50,7 +50,17 @@ UNITE_DOIS = {
             True: "10.15156/BIO/2938082",
         },
     },
-    # Old version 9.0 is not listed here
+    "2022-10-16": {
+        "fungi": {
+            False: "10.15156/BIO/2483915",
+            True: "10.15156/BIO/2483916",
+        },
+        "eukaryotes": {
+            False: "10.15156/BIO/2483917",
+            True: "10.15156/BIO/2483918",
+        },
+    },
+
     "2021-05-10": {
         "fungi": {
             False: "10.15156/BIO/1264708",

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1004,7 +1004,8 @@ plugin.methods.register_function(
     function=get_unite_data,
     inputs={},
     parameters={
-        'version': Str % Choices(['10.0', '9.0', '8.3', '8.2']),
+        'version': Str % Choices(['2025-02-19', '2023-07-18', '2021-05-10',
+                                  '2020-02-20']),
         'taxon_group': Str % Choices(['fungi', 'eukaryotes']),
         'cluster_id': Str % Choices(['99', '97', 'dynamic']),
         'singletons': Bool,

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1004,8 +1004,8 @@ plugin.methods.register_function(
     function=get_unite_data,
     inputs={},
     parameters={
-        'version': Str % Choices(['2025-02-19', '2023-07-18', '2021-05-10',
-                                  '2020-02-20']),
+        'version': Str % Choices(['2025-02-19', '2024-04-04', '2023-07-18',
+                                  '2021-05-10', '2020-02-20']),
         'taxon_group': Str % Choices(['fungi', 'eukaryotes']),
         'cluster_id': Str % Choices(['99', '97', 'dynamic']),
         'singletons': Bool,

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1005,7 +1005,7 @@ plugin.methods.register_function(
     inputs={},
     parameters={
         'version': Str % Choices(['2025-02-19', '2024-04-04', '2023-07-18',
-                                  '2021-05-10', '2020-02-20']),
+                                  '2022-10-16', '2021-05-10', '2020-02-20']),
         'taxon_group': Str % Choices(['fungi', 'eukaryotes']),
         'cluster_id': Str % Choices(['99', '97', 'dynamic']),
         'singletons': Bool,

--- a/rescript/tests/test_get_unite.py
+++ b/rescript/tests/test_get_unite.py
@@ -86,7 +86,7 @@ class TestGetUNITE(TestPluginBase):
             "rescript.get_unite._unite_get_tgz", return_value=self.unitefile
         ):
             res = get_unite_data(
-                version="8.3", taxon_group="fungi", cluster_id="97"
+                version="2021-05-10", taxon_group="fungi", cluster_id="97"
             )
             self.assertEqual(len(res), 2)
             self.assertTrue(isinstance(res[0], pandas.core.frame.DataFrame))


### PR DESCRIPTION
Addresses #216.

Replaces version, *e.g.* `10.0` with the latest release date `2025-02-19` (and doi) for that version.
