### PR TITLE
ENHL adds ability to toggle GTDB download url.

### DIFF
--- a/rescript/get_gtdb.py
+++ b/rescript/get_gtdb.py
@@ -36,11 +36,13 @@ def get_gtdb_data(
     version: str = '226.0',
     domain: str = 'Both',
     db_type: str = 'SpeciesReps',
+    url_type: str = 'Primary'
         ) -> (TSVTaxonomyFormat, DNAFASTAFormat):
 
     queries = _assemble_queries(version=version,
                                 db_type=db_type,
-                                domain=domain)
+                                domain=domain,
+                                url_type=url_type)
     tax_q, seqs_q = _retrieve_data_from_gtdb(queries)
 
     print('\n Saving files...\n')
@@ -49,9 +51,15 @@ def get_gtdb_data(
 
 def _assemble_queries(version='226.0',
                       db_type='SpeciesReps',
-                      domain='Both'):
+                      domain='Both',
+                      url_type='Primary'):
     queries = []
-    base_url = 'https://data.gtdb.ecogenomic.org/releases/'
+
+    if url_type == 'Primary':
+        base_url = 'https://data.gtdb.ecogenomic.org/releases/'
+    elif url_type == 'Mirror':
+        base_url = 'https://data.ace.uq.edu.au/public/gtdb/data/releases/'
+
     base_version = version.split('.')[0]
     # ^^ Set `base_version` variable becuase number after the decimal is
     # only used for the directory. GTDB trims this off for the actual

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1020,7 +1020,7 @@ plugin.methods.register_function(
         'url_type': 'Toggle download URL. \'Primary\' will download data '
                     'from the primary GTDB URL. \'Mirror\' will dowload data '
                     'from the GTDB data mirror. Use \'Mirror\' if downloads '
-                    'from \'Primary\'are slow.'},
+                    'from \'Primary\' are slow.'},
     output_descriptions={
         'gtdb_taxonomy': 'SSU GTDB reference taxonomy.',
         'gtdb_sequences': 'SSU GTDB reference sequences.'},

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -995,7 +995,8 @@ plugin.methods.register_function(
         'version': Str % Choices(['202.0', '207.0', '214.0', '214.1',
                                   '220.0', '226.0']),
         'domain': Str % Choices(['Both', 'Bacteria', 'Archaea']),
-        'db_type': Str % Choices(['All', 'SpeciesReps'])
+        'db_type': Str % Choices(['All', 'SpeciesReps']),
+        'url_type': Str % Choices(['Primary', 'Mirror'])
         },
     outputs=[('gtdb_taxonomy', FeatureData[Taxonomy]),
              ('gtdb_sequences', FeatureData[Sequence])],
@@ -1015,7 +1016,11 @@ plugin.methods.register_function(
                    'species. Note: if \'All\' is used, the \'domain\' '
                    'parameter will be ignored as GTDB does not maintain '
                    'separate domain-level files for these non-clustered '
-                   'data.'},
+                   'data.',
+        'url_type': 'Toggle download URL. \'Primary\' will download data '
+                    'from the primary GTDB URL. \'Mirror\' will dowload data '
+                    'from the GTDB data mirror. Use \'Mirror\' if downloads '
+                    'from \'Primary\'are slow.'},
     output_descriptions={
         'gtdb_taxonomy': 'SSU GTDB reference taxonomy.',
         'gtdb_sequences': 'SSU GTDB reference sequences.'},

--- a/rescript/tests/test_get_gtdb.py
+++ b/rescript/tests/test_get_gtdb.py
@@ -96,13 +96,35 @@ class TestGetGTDB(TestPluginBase):
             except HTTPError:
                 raise ValueError('Failed to open URL: ' + u)
 
-    def test_assemble_queries_all(self):
-        obs_query_urls = _assemble_queries('207.0', 'All')
+    def test_assemble_queries_all_primary(self):
+        obs_query_urls = _assemble_queries(version='207.0',
+                                           db_type='All',
+                                           url_type='Primary')
         print('obs queries: ', obs_query_urls)
 
         exp_query_urls = [('All',
                            'https://data.gtdb.ecogenomic.org/releases/'
                            'release207/207.0/genomic_files_all/'
+                           'ssu_all_r207.tar.gz')]
+        print('exp queries: ', exp_query_urls)
+        self.assertEqual(obs_query_urls, exp_query_urls)
+
+        # test that these URLs work
+        for _, u in obs_query_urls:
+            try:
+                urlopen(u)
+            except HTTPError:
+                raise ValueError('Failed to open URL: ' + u)
+
+    def test_assemble_queries_all_mirror(self):
+        obs_query_urls = _assemble_queries(version='207.0',
+                                           db_type='All',
+                                           url_type='Mirror')
+        print('obs queries: ', obs_query_urls)
+
+        exp_query_urls = [('All',
+                           'https://data.ace.uq.edu.au/public/gtdb/data/'
+                           'releases/release207/207.0/genomic_files_all/'
                            'ssu_all_r207.tar.gz')]
         print('exp queries: ', exp_query_urls)
         self.assertEqual(obs_query_urls, exp_query_urls)


### PR DESCRIPTION
Fixes #228.

If downloads from the primary GTDB host site are slow, *i.e.* `--p-url-type 'Primary'`, user can switch to using the GTDB mirror site by using `--p-url-type 'Mirror'`