### PR TITLE
ENH: Added `get-eukaryome-data`.

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,6 +16,7 @@ requirements:
   - ncbi-datasets-pyclient >=17.0.0
   - requests
   - xmltodict
+  - py7zr
   - pandas {{ pandas }}
   - vsearch >=2.21.1
   - scikit-learn {{ scikit_learn }}

--- a/rescript/citations.bib
+++ b/rescript/citations.bib
@@ -218,3 +218,21 @@
   doi = {10.1002/edn3.303},
   url = {https://onlinelibrary.wiley.com/doi/10.1002/edn3.303},
 }
+
+@ARTICLE{Tedersoo2024,
+  title = {EUKARYOME: the rRNA gene reference database for
+           identification of all eukaryotes},
+  author = {Tedersoo, Leho and Hosseyni Moghaddam, Mahdieh S and Mikryukov,
+            Vladimir and Hakimzadeh, Ali and Bahram, Mohammad and Nilsson, R
+            Henrik and Yatsiuk, Iryna and Geisen, Stefan and Schwelm, Arne
+            and Piwosz, Kasia and Prous, Marko and Sildever, Sirje and
+            Chmolowska, Dominika and Rueckert, Sonja and Skaloud, Pavel and
+            Laas, Peeter and Tines, Marco and Jung, Jae-Ho and Choi, Ji Hye
+            and Alkahtani, Saad and Anslan, Sten},
+  journal = {Database (Oxford)},
+  publisher = {Oxford University Press},
+  volume = {2024},
+  year = {2024},
+  doi = {10.1093/database/baae043},
+  url = {https://doi.org/10.1093/database/baae043}
+}

--- a/rescript/get_eukaryome.py
+++ b/rescript/get_eukaryome.py
@@ -1,0 +1,138 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2019-2025, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+import os
+import tempfile
+import zipfile
+import py7zr
+from urllib.request import urlretrieve
+from urllib.error import HTTPError
+import warnings
+import pandas as pd
+from q2_types.feature_data import (TSVTaxonomyFormat, DNAFASTAFormat,
+                                   DNAIterator)
+
+RRNA_GENE_LIST = ['SSU', 'LSU', 'ITS', 'longread', 'all']
+
+
+def _assemble_rrna_url(rrna_gene,
+                       version='1.9.4',
+                       ):
+
+    base_url = ('https://sisu.ut.ee/wp-content/uploads/sites/643/'
+                'General_EUK_{gene}_v{ver}.zip')
+
+    base_format_dict = {'gene': rrna_gene,
+                        'ver': version}
+
+    rrna_url = base_url.format(**base_format_dict)
+    return rrna_url
+
+
+def _get_eukaryome_data_path(tmpdirname, url, basename):
+    destination = os.path.join(tmpdirname, basename)
+    try:
+        print('Retrieving data from {0}'.format(url))
+        urlretrieve(url, destination)
+    except HTTPError:
+        msg = ("    Unable to retrieve the followng file from Eukaryome:\n "
+               + url)
+        warnings.warn(msg, UserWarning)
+    return destination
+
+
+def _extract_zip_euk_seq_file(tmpdirname, uncompressed_base_fn, fasta_zfp):
+    uncompressed_fn = uncompressed_base_fn + '.fasta'
+    out_path = os.path.join(tmpdirname, uncompressed_fn)
+    with zipfile.ZipFile(fasta_zfp, 'r') as zipf:
+        zipf.extract(uncompressed_fn, tmpdirname)
+        seqs = DNAFASTAFormat(out_path, mode="r").view(DNAIterator)
+    return seqs
+
+
+def _extract_7zip_euk_seq_file(tmpdirname, uncompressed_base_fn, fasta_zfp):
+    uncompressed_7z_fn = uncompressed_base_fn + '.7z'
+    uncompressed_fn = uncompressed_base_fn + '.fasta'
+    compressed_out_path = os.path.join(tmpdirname,  uncompressed_7z_fn)
+    uncompressed_out_path = os.path.join(tmpdirname, uncompressed_fn)
+
+    with zipfile.ZipFile(fasta_zfp, 'r') as zipf:
+        zipf.extract(uncompressed_7z_fn, tmpdirname)
+        with py7zr.SevenZipFile(compressed_out_path, mode='r') as zip7f:
+            zip7f.extract(path=tmpdirname, targets=[uncompressed_fn])
+            seqs = DNAFASTAFormat(uncompressed_out_path,
+                                  mode="r").view(DNAIterator)
+    return seqs
+
+
+def _retrieve_data_from_eukaryome(rrna_url, gene):
+    proc_seqs = DNAFASTAFormat()
+    proc_tax = TSVTaxonomyFormat()
+    tax_dict = {}
+
+    with \
+        tempfile.TemporaryDirectory() as tmpdirname, \
+            proc_seqs.open() as out_fasta, \
+            proc_tax.open() as out_tax:
+
+        basename = os.path.basename(rrna_url)
+        uncompressed_base_fn = basename.rsplit('.', 1)[0]
+
+        fasta_zfp = _get_eukaryome_data_path(tmpdirname, rrna_url,
+                                             basename)
+
+        print('  Processing \'{0}\' data ...'.format(gene))
+        if gene == 'ITS':
+            seqs = _extract_7zip_euk_seq_file(tmpdirname,
+                                              uncompressed_base_fn,
+                                              fasta_zfp)
+        else:
+            seqs = _extract_zip_euk_seq_file(tmpdirname,
+                                             uncompressed_base_fn,
+                                             fasta_zfp)
+
+        print('    Processing sequences ...')
+        for seq in seqs:
+            seqid, tax = seq.metadata['id'].split(';', 1)
+            out_fasta.write('>' + seqid + '\n' + str(seq) + '\n')
+            tax_dict[seqid] = tax
+        print('    Sequences processed.')
+        print('    Processing taxonomy...')
+        parsed_taxonomy_df = pd.DataFrame.from_dict(tax_dict, orient='index')
+        parsed_taxonomy_df.index.name = 'Feature ID'
+        parsed_taxonomy_df.rename(columns={parsed_taxonomy_df.columns[0]:
+                                           'Taxon'}, inplace=True)
+        parsed_taxonomy_df.to_csv(out_tax, sep='\t')
+        print('    Taxonomy processed.')
+        return proc_seqs, proc_tax
+
+
+def get_eukaryome_data(
+    rrna_gene: list,
+    version: str = '1.9.4',
+        ) -> (DNAFASTAFormat, TSVTaxonomyFormat):
+
+    seq_res = {}
+    tax_res = {}
+
+    if 'all' in rrna_gene:
+        RRNA_GENE_LIST.pop()  # remove 'all' from choices.
+        rrna_gene = RRNA_GENE_LIST
+
+    for gene in rrna_gene:
+        rrna_url = _assemble_rrna_url(
+                                  rrna_gene=gene,
+                                  version=version,
+                                  )
+
+        seqs, tax = _retrieve_data_from_eukaryome(rrna_url, gene)
+        seq_res[gene + '_seqs'] = seqs
+        tax_res[gene + '_taxa'] = tax
+
+    print('\n Saving files...\n')
+    return seq_res, tax_res

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -58,6 +58,7 @@ from .get_gtdb import get_gtdb_data
 from .get_unite import get_unite_data
 from .get_pr2 import get_pr2_data, _allowed_pr2_ranks, _default_pr2_ranks
 from .get_midori2 import get_midori2_data, MITO_GENE_LIST
+from .get_eukaryome import get_eukaryome_data
 
 citations = Citations.load('citations.bib', package='rescript')
 
@@ -98,6 +99,10 @@ PR2_LICENSE_NOTE = (
 MIDORI2_LICENSE_NOTE = (
     'NOTE: THIS ACTION ACQUIRES DATA FROM MIDORI2. To learn '
     'more, please visit https://www.reference-midori.info/.')
+
+EUKARYOME_LICENSE_NOTE = (
+    'NOTE: THIS ACTION ACQUIRES DATA FROM EUKARYOME. To learn '
+    'more, please visit https://eukaryome.org/.')
 
 LINEPLOT_XAXIS_INTERPRETATION = (
     'The x-axis in these plots represents the taxonomic '
@@ -1150,6 +1155,40 @@ plugin.methods.register_function(
         'sequences with unspecified species information should be '
         'downloaded. ' + MIDORI2_LICENSE_NOTE),
     citations=[citations['Leray2022midori2']]
+)
+
+
+plugin.methods.register_function(
+    function=get_eukaryome_data,
+    inputs={},
+    parameters={
+        'version': Str % Choices(['1.9.4', '1.9.3', '1.9.2']),
+        'rrna_gene': List[Str % Choices(['SSU', 'LSU', 'ITS',
+                                        'longread', 'all'])],
+        },
+    outputs=[('eukaryome_sequences', Collection[FeatureData[Sequence]]),
+             ('eukaryome_taxonomy', Collection[FeatureData[Taxonomy]])],
+    input_descriptions={},
+    parameter_descriptions={
+        'version': 'Eukaryome version to download.',
+        'rrna_gene': 'Download the rRNA gene(s) of interest. '
+                     'Specify the respective gene(s), or download all genes '
+                     'using \'all\'.',
+        },
+    output_descriptions={
+        'eukaryome_sequences': 'Eukaryome reference sequence output '
+                               'directory.',
+        'eukaryome_taxonomy': 'Eukaryome reference taxonomy output '
+                              'directory.'},
+    name='Download and import Eukaryome reference data.',
+    description=(
+        'Download and import a variety of rRNA gene sequences '
+        'along with their associated taxonomy from the Eukaryome database. '
+        'Simply provide the database version, the rRNA gene '
+        'of interest, the reference sequence type, and if reference '
+        'sequences with unspecified species information should be '
+        'downloaded. ' + EUKARYOME_LICENSE_NOTE),
+    citations=[citations['Tedersoo2024']]
 )
 
 


### PR DESCRIPTION
This PR adds `get-eukaryome-data` to fetch data from [Eukaryome](https://eukaryome.org/). This PR also adds the dependency `py7zr` as the ITS data is a `7zip` file contained within a `zip` file.

The user will be able to download the following sequences:
 - Referense SSU sequences.
 - Reference LSU sequences.
 - Reference ITS sequences.
 - Reference long read sequences (*i.e.* SSU-ITS-LSU sequences combined).

Use can download several or `all` databases.

To do:
- [ ] Write test code.