### PR TITLE
ENH: adding new DBs to `get-midori2-data`

### DIFF
--- a/rescript/get_midori2.py
+++ b/rescript/get_midori2.py
@@ -22,7 +22,7 @@ MITO_GENE_LIST = ['A6', 'A8', 'CO1', 'CO2', 'CO3', 'Cytb',
 
 
 def _assemble_midori2_urls(mito_gene,
-                           version='GenBank265_2025-03-08',
+                           version='GenBank267_2025-06-19',
                            ref_seq_type='uniq',
                            unspecified_species=False,
                            ):
@@ -94,7 +94,7 @@ def _retrieve_data_from_midori2(fasta_url, tax_url):
 #     `--p-search-strings '_\d+(;)|_\d+($)'`.
 def get_midori2_data(
     mito_gene: list,
-    version: str = 'GenBank265_2025-03-08',
+    version: str = 'GenBank267_2025-06-19',
     ref_seq_type: str = 'uniq',
     unspecified_species: bool = False,
         ) -> (DNAIterator, pd.DataFrame):

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1116,10 +1116,10 @@ plugin.methods.register_function(
     inputs={},
     parameters={
         'version': Str % Choices(
-                    ['GenBank267_2025-06-19', 'GenBank265_2025-03-08',
-                     'GenBank264_2024-12-14', 'GenBank263_2024-10-13',
-                     'GenBank262_2024-08-16', 'GenBank261_2024-06-15',
-                     'GenBank260_2024-04-15']),
+                    ['GenBank267_2025-06-19', 'GenBank266_2025-04-24',
+                     'GenBank265_2025-03-08', 'GenBank264_2024-12-14',
+                     'GenBank263_2024-10-13', 'GenBank262_2024-08-16',
+                     'GenBank261_2024-06-15', 'GenBank260_2024-04-15']),
         'mito_gene': List[Str % Choices(MITO_GENE_LIST)],
         'ref_seq_type': Str % Choices(['uniq', 'longest']),
         'unspecified_species': Bool,

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1116,9 +1116,10 @@ plugin.methods.register_function(
     inputs={},
     parameters={
         'version': Str % Choices(
-                    ['GenBank265_2025-03-08', 'GenBank264_2024-12-14',
-                     'GenBank263_2024-10-13', 'GenBank262_2024-08-16',
-                     'GenBank261_2024-06-15', 'GenBank260_2024-04-15']),
+                    ['GenBank267_2025-06-19', 'GenBank265_2025-03-08',
+                     'GenBank264_2024-12-14', 'GenBank263_2024-10-13',
+                     'GenBank262_2024-08-16', 'GenBank261_2024-06-15',
+                     'GenBank260_2024-04-15']),
         'mito_gene': List[Str % Choices(MITO_GENE_LIST)],
         'ref_seq_type': Str % Choices(['uniq', 'longest']),
         'unspecified_species': Bool,

--- a/rescript/tests/test_get_midori2.py
+++ b/rescript/tests/test_get_midori2.py
@@ -70,7 +70,7 @@ class TestGetMidori2(TestPluginBase):
         self.assertEqual(tax_url, exp_tax_url)
 
     @patch("rescript.get_midori2.urlretrieve")
-    def test_run_amrfinder_u_error(self, mock_urlretrieve):
+    def test_run_midori_error(self, mock_urlretrieve):
         expected_message = ("Unable to retrieve the following "
                             "file from MIDORI2:\n"
                             "url_seq\n: Simulated network error")


### PR DESCRIPTION
This PR is simply adding the recent `GenBank266_2025-04-24` & `GenBank267_2025-06-19` MIDORI2 databases available from [here](https://www.reference-midori.info/download.php).

I also fixed a typo in `test_get_midori2.py`.

*If this passes the GitHub checks I'll merge, as there is no new code to be reviewed.*