### PR TITLE
FIX: correctly set the DB param before the EFetch request

### DIFF
--- a/rescript/ncbi.py
+++ b/rescript/ncbi.py
@@ -243,7 +243,7 @@ def _esearch(params, logging_level, entrez_delay=0.334):
         if 'WebEnv' not in webenv:
             raise ValueError('No sequences for given query')
         params = dict(
-            db='nuccore', rettype='fasta', retmode='xml',
+            rettype='fasta', retmode='xml',
             WebEnv=webenv['WebEnv'],
             query_key=webenv['QueryKey'], **_entrez_params
         )
@@ -387,9 +387,9 @@ def get_data_for_query(query, logging_level, n_jobs, request_lock,
     )
     params, expected_num_records = _esearch(params, logging_level,
                                             entrez_delay)
+    params['db'] = db
     if expected_num_records > 166666:
         _large_warning(logging_level)
-    records = []
     logger = _get_logger(logging_level)
     logger.info('Downloading ' + str(expected_num_records) + ' sequences')
 


### PR DESCRIPTION
When using `query` to fetch protein sequences we would make two requests: esearch + efetch. The DB for the first was set correctly, while for the second one it was hardcoded to "nuccore" (which is incorrect for fetching protein sequences). The code was updated to dynamically set the DB for the second request, depending on the DB used for the first request.

Note: I'm not sure why this worked before but perhaps NCBI just started enforcing passing the correct DB in the linked EFetch request...