### PR TITLE
ENH: adds database v2 for `get-eukaryome-data`

### DIFF
--- a/rescript/get_eukaryome.py
+++ b/rescript/get_eukaryome.py
@@ -19,7 +19,7 @@ RRNA_GENE_LIST = ['SSU', 'LSU', 'ITS', 'longread', 'all']
 
 
 def _assemble_rrna_url(rrna_gene,
-                       version='1.9.4',
+                       version='2.0',
                        ):
 
     base_url = ('https://sisu.ut.ee/wp-content/uploads/sites/643/'
@@ -46,26 +46,31 @@ def _get_eukaryome_data_path(tmpdirname, url, basename):
 
 
 def _extract_zip_euk_seq_file(tmpdirname, uncompressed_base_fn, fasta_zfp):
-    uncompressed_fn = uncompressed_base_fn + '.fasta'
-    out_path = os.path.join(tmpdirname, uncompressed_fn)
-    with zipfile.ZipFile(fasta_zfp, 'r') as zipf:
-        zipf.extract(uncompressed_fn, tmpdirname)
-        seqs = DNAFASTAFormat(out_path, mode="r").view(DNAIterator)
-    return seqs
-
-
-def _extract_7zip_euk_seq_file(tmpdirname, uncompressed_base_fn, fasta_zfp):
+    # In later DBs, ITS files may not be within a nested 7z file.
     uncompressed_7z_fn = uncompressed_base_fn + '.7z'
     uncompressed_fn = uncompressed_base_fn + '.fasta'
     compressed_out_path = os.path.join(tmpdirname,  uncompressed_7z_fn)
     uncompressed_out_path = os.path.join(tmpdirname, uncompressed_fn)
 
     with zipfile.ZipFile(fasta_zfp, 'r') as zipf:
-        zipf.extract(uncompressed_7z_fn, tmpdirname)
-        with py7zr.SevenZipFile(compressed_out_path, mode='r') as zip7f:
-            zip7f.extract(path=tmpdirname, targets=[uncompressed_fn])
+        nl = zipf.namelist()
+        if uncompressed_fn in nl:
+            zipf.extract(uncompressed_fn, tmpdirname)
             seqs = DNAFASTAFormat(uncompressed_out_path,
                                   mode="r").view(DNAIterator)
+        elif uncompressed_7z_fn in nl:
+            zipf.extract(uncompressed_7z_fn, tmpdirname)
+            with py7zr.SevenZipFile(compressed_out_path, mode='r') as zip7f:
+                zip7f.extract(path=tmpdirname, targets=[uncompressed_fn])
+                seqs = DNAFASTAFormat(uncompressed_out_path,
+                                      mode="r").view(DNAIterator)
+        else:
+            raise FileNotFoundError(
+                            "Neither the %s nor the "
+                            "%s files were found within "
+                            "the archive." % (uncompressed_7z_fn,
+                                              uncompressed_fn)
+                            )
     return seqs
 
 
@@ -112,14 +117,10 @@ def _retrieve_data_from_eukaryome(rrna_url, gene):
                                              basename)
 
         print('  Processing \'{0}\' data ...'.format(gene))
-        if gene == 'ITS':
-            seqs = _extract_7zip_euk_seq_file(tmpdirname,
-                                              uncompressed_base_fn,
-                                              fasta_zfp)
-        else:
-            seqs = _extract_zip_euk_seq_file(tmpdirname,
-                                             uncompressed_base_fn,
-                                             fasta_zfp)
+
+        seqs = _extract_zip_euk_seq_file(tmpdirname,
+                                         uncompressed_base_fn,
+                                         fasta_zfp)
 
         print('    Processing sequences ...')
         proc_seqs, proc_tax = _process_eukaryome_data(seqs)
@@ -128,7 +129,7 @@ def _retrieve_data_from_eukaryome(rrna_url, gene):
 
 def get_eukaryome_data(
     rrna_gene: list,
-    version: str = '1.9.4',
+    version: str = '2.0',
         ) -> (DNAFASTAFormat, TSVTaxonomyFormat):
 
     seq_res = {}

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1072,7 +1072,8 @@ plugin.methods.register_function(
     function=get_eukaryome_data,
     inputs={},
     parameters={
-        'version': Str % Choices(['2.0', '1.9.4', '1.9.3', '1.9.2']),
+        'version': Str % Choices(['2.0', '1.9.4', '1.9.3', '1.9']),
+        # Note: 1.9 is actually 1.9.2
         'rrna_gene': List[Str % Choices(RRNA_GENE_LIST)],
         },
     outputs=[('eukaryome_sequences', Collection[FeatureData[Sequence]]),

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1072,7 +1072,7 @@ plugin.methods.register_function(
     function=get_eukaryome_data,
     inputs={},
     parameters={
-        'version': Str % Choices(['1.9.4', '1.9.3', '1.9.2']),
+        'version': Str % Choices(['2.0', '1.9.4', '1.9.3', '1.9.2']),
         'rrna_gene': List[Str % Choices(RRNA_GENE_LIST)],
         },
     outputs=[('eukaryome_sequences', Collection[FeatureData[Sequence]]),

--- a/rescript/tests/test_get_eukaryome.py
+++ b/rescript/tests/test_get_eukaryome.py
@@ -55,10 +55,10 @@ class TestGetEukaryome(TestPluginBase):
     def test_assemble_rrna_url_02(self):
         obs_url = _assemble_rrna_url(
                             rrna_gene='longread',
-                            version='1.9.2')
+                            version='1.9')
         exp_url = (
                  'https://sisu.ut.ee/wp-content/uploads/sites/643/'
-                 'General_EUK_longread_v1.9.2.zip')
+                 'General_EUK_longread_v1.9.zip')
         self.assertEqual(obs_url, exp_url)
 
     def test_extract_zip_euk_seq_file(self):

--- a/rescript/tests/test_get_eukaryome.py
+++ b/rescript/tests/test_get_eukaryome.py
@@ -12,9 +12,7 @@ from rescript.get_eukaryome import (_assemble_rrna_url,
                                     _retrieve_data_from_eukaryome,
                                     _make_fasta_str, _make_taxonomy_df,
                                     _process_eukaryome_data,
-                                    _extract_zip_euk_seq_file,
-                                    _extract_7zip_euk_seq_file
-                                    )
+                                    _extract_zip_euk_seq_file)
 from q2_types.feature_data import (TSVTaxonomyFormat,
                                    DNAFASTAFormat,
                                    DNAIterator)
@@ -35,7 +33,6 @@ class TestGetEukaryome(TestPluginBase):
         self.eukaryome_fasta = self.get_data_path('eukaryome-seqs.fasta')
         self.eukaryome_seqs = DNAFASTAFormat(
                             self.eukaryome_fasta,
-                            # self.get_data_path('eukaryome-seqs.fasta'),
                             mode='r')
         self.eukaryome_parsed_fasta = \
             self.get_data_path('eukaryome-parsed-seqs.fasta')
@@ -80,7 +77,7 @@ class TestGetEukaryome(TestPluginBase):
                              for seq in obs_uzs}
             self.assertEqual(exp_seqs_dict, obs_seqs_dict)
 
-    def test_extract_7zip_euk_seq_file(self):
+    def test_extract_zip_euk_seq_file_7zip(self):
         with tempfile.TemporaryDirectory() as tmpdirname:
             zfn = os.path.join(tmpdirname, 'eukaryome-pseqs.zip')
             with zipfile.ZipFile(zfn, "w", zipfile.ZIP_DEFLATED) as myzip:
@@ -90,7 +87,7 @@ class TestGetEukaryome(TestPluginBase):
                                arcname='eukaryome-pseqs.fasta')
                 myzip.write(szfn, arcname='eukaryome-pseqs.7z')
 
-            obs_uzs = _extract_7zip_euk_seq_file(
+            obs_uzs = _extract_zip_euk_seq_file(
                         tmpdirname, 'eukaryome-pseqs', zfn)
             exp_seqs_dict = {seq.metadata['id'].split(';', 1)[0]: str(seq)
                              for seq in self.eukaryome_parsed_seqs.view(
@@ -98,6 +95,17 @@ class TestGetEukaryome(TestPluginBase):
             obs_seqs_dict = {seq.metadata['id']: str(seq)
                              for seq in obs_uzs}
             self.assertEqual(exp_seqs_dict, obs_seqs_dict)
+
+    def test_extract_zip_euk_seq_file_filenotfound(self):
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            zfn = os.path.join(tmpdirname, 'eukaryome-pseqs.zip')
+            with zipfile.ZipFile(zfn, "w", zipfile.ZIP_DEFLATED) as myzip:
+                myzip.write(self.eukaryome_parsed_fasta,
+                            arcname='eukaryome-pseqs.NOT_USABLE')
+
+            with self.assertRaises(FileNotFoundError):
+                _extract_zip_euk_seq_file(tmpdirname,
+                                          'eukaryome-pseqs', zfn)
 
     def test_make_fasta_str(self):
         seqid = 'Seq01'


### PR DESCRIPTION
This PR partially fixes #255, specifically related to `get-eukaryome-data`.

- Can now retrieve data for database v 2.0
- Code refactored and condensed.
  - ITS sequence files for version 2.0 are no longer contained within a 7zip file within a zip file. Code was refactored and condensed to be able to handle both cases.
  - Unit tests also updated to reflect code changes.  