### PR TITLE
ENH: updated midori 2 databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,9 @@ However, other resources accessible via RESCRIPt are released under different li
 **If using GTDB data** (*e.g.*, with `get-gtdb-data`): See the [GTDB "about" page](https://gtdb.ecogenomic.org/about) for more details. [How to cite GTDB](https://gtdb.ecogenomic.org/about).
 
 **If using UNITE data** (*e.g.*, with `get-unite-data`): See the [UNITE citation page](https://unite.ut.ee/cite.php) for more details. [How to cite UNITE](https://unite.ut.ee/cite.php). 
+
+**If using PR2 data** (*e.g.*, with `get-pr2-data`): See [The PR2 Databases](https://pr2-database.org/) for more details. [How to cite PR2](https://pr2-database.org/papers/papers-citing-pr2/).
+
+**If using MIDORI2 data** (*e.g.*, with `get-midori2-data`): See [MIDORI Refrence 2](https://www.reference-midori.info) for more details. [How to cite MIDORI2](https://www.reference-midori.info/).
+
+**If using EUKARYOME data** (*e.g.*, with `get-eukaryome-data`): See [EUKARYOME](https://eukaryome.org/) for more details. [How to cite Eukaryome](https://eukaryome.org/).

--- a/rescript/get_midori2.py
+++ b/rescript/get_midori2.py
@@ -22,7 +22,7 @@ MITO_GENE_LIST = ['A6', 'A8', 'CO1', 'CO2', 'CO3', 'Cytb',
 
 
 def _assemble_midori2_urls(mito_gene,
-                           version='GenBank267_2025-06-19',
+                           version='GenBank270_2026-02-15',
                            ref_seq_type='uniq',
                            unspecified_species=False,
                            ):
@@ -94,7 +94,7 @@ def _retrieve_data_from_midori2(fasta_url, tax_url):
 #     `--p-search-strings '_\d+(;)|_\d+($)'`.
 def get_midori2_data(
     mito_gene: list,
-    version: str = 'GenBank267_2025-06-19',
+    version: str = 'GenBank270_2026-02-15',
     ref_seq_type: str = 'uniq',
     unspecified_species: bool = False,
         ) -> (DNAIterator, pd.DataFrame):

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -1030,7 +1030,9 @@ plugin.methods.register_function(
     inputs={},
     parameters={
         'version': Str % Choices(
-                    ['GenBank267_2025-06-19', 'GenBank266_2025-04-24',
+                    ['GenBank270_2026-02-15',
+                     'GenBank269_2025-12-09', 'GenBank268_2025-08-14',
+                     'GenBank267_2025-06-19', 'GenBank266_2025-04-24',
                      'GenBank265_2025-03-08', 'GenBank264_2024-12-14',
                      'GenBank263_2024-10-13', 'GenBank262_2024-08-16',
                      'GenBank261_2024-06-15', 'GenBank260_2024-04-15']),


### PR DESCRIPTION
Completes fixes to #255. 

- Adds the following databases to `get-midori2-data`:
  - `GenBank270_2026-02-15`
  - `GenBank269_2025-12-09`  
  - `GenBank268_2025-08-14`  
- Updated README to include references for:
  - [PR2](https://pr2-database.org/)
  - [EUKARYOME](https://eukaryome.org/)
  - [MIDORI2](https://www.reference-midori.info)
 
Also corrected:
- `gzip.open(in_path, 'rt')` to  `gzip.open(in_path, 'rb')`
- `open(out_path, 'w')` to `open(out_path, 'wb')`