### PR TITLE
BUG: Fixes SILVA 144 Handling.

### DIFF
--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -20,15 +20,17 @@ from q2_types.feature_data import RNAFASTAFormat
 
 
 def get_silva_data(ctx,
-                   version='138.2',
+                   version='144',
                    target='SSURef_NR99',
+                   trunc=True,
                    include_species_labels=False,
                    rank_propagation=True,
                    ranks=None,
                    download_sequences=True):
     # download data from SILVA
     print('Downloading raw files may take some time... get some coffee.')
-    queries = _assemble_silva_data_urls(version, target, download_sequences)
+    queries = _assemble_silva_data_urls(version, target, trunc,
+                                        download_sequences)
     results = _retrieve_data_from_silva(queries)
     # parse taxonomy
     parse_taxonomy = ctx.get_action('rescript', 'parse_silva_taxonomy')
@@ -46,7 +48,8 @@ def get_silva_data(ctx,
     return results['sequences'], taxonomy
 
 
-def _assemble_silva_data_urls(version, target, download_sequences=True):
+def _assemble_silva_data_urls(version, target, trunc=True,
+                              download_sequences=True):
     '''Generate SILVA urls, given database version and reference target.'''
     # assemble target urls
     ref_map = {'SSURef_NR99': 'ssu_ref_nr',
@@ -70,8 +73,14 @@ def _assemble_silva_data_urls(version, target, download_sequences=True):
     # if we find more inconsistencies.
 
     # construct file urls
-    base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva.fasta.gz'.format(
-        version, target)
+    if trunc:
+        ts = '_trunc'
+    else:
+        ts = ''
+
+    base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva{2}.fasta.gz'.format(
+            version, target, ts)
+
     base_url_taxmap = '{0}taxonomy/taxmap_slv_{1}_{2}'.format(
         base_url, insert, version)
 
@@ -82,8 +91,16 @@ def _assemble_silva_data_urls(version, target, download_sequences=True):
         base_url_taxmap += '.txt.gz'
     base_url_tax = '{0}taxonomy/tax_slv_{1}_{2}'.format(
         base_url, insert.split('_')[0], version)
-    tree_url = base_url_tax + '.tre'
-    tax_url = base_url_tax + '.txt'
+
+    # tree & taxonomy urls
+    #  if version 144 or greater:
+    if float(version) >= 144:
+        gz_str = '.gz'
+    else:
+        gz_str = ''
+
+    tree_url = base_url_tax + '.tre' + gz_str
+    tax_url = base_url_tax + '.txt' + gz_str
 
     # add ".gz" for the following versions:
     if version in ['138', '138.1', '138.2']:

--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -81,8 +81,17 @@ def _assemble_silva_data_urls(version, target, trunc=True,
     base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva{2}.fasta.gz'.format(
             version, target, ts)
 
-    base_url_taxmap = '{0}taxonomy/taxmap_slv_{1}_{2}'.format(
-        base_url, insert, version)
+    # SILVA 144 taxmap file schema has changed to
+    # `taxmap_slv_ssu_ref144.txt.gz`
+    # Prior versions of silva have always been in the form of:
+    #  `taxmap_slv_ssu_ref_144.txt.gz`
+    if target == 'SSURef' and float(version) >= 144:
+        under = ''
+    else:
+        under = '_'
+
+    base_url_taxmap = '{0}taxonomy/taxmap_slv_{1}{2}{3}'.format(
+        base_url, insert, under, version)
 
     # More SILVA release inconsistencies
     if target == 'SSURef' and version == '132':

--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -93,17 +93,10 @@ def _assemble_silva_data_urls(version, target, trunc=True,
         base_url, insert.split('_')[0], version)
 
     # tree & taxonomy urls
-    #  if version 144 or greater:
-    if float(version) >= 144:
-        gz_str = '.gz'
-    else:
-        gz_str = ''
-
-    tree_url = base_url_tax + '.tre' + gz_str
-    tax_url = base_url_tax + '.txt' + gz_str
-
+    tree_url = base_url_tax + '.tre'
+    tax_url = base_url_tax + '.txt'
     # add ".gz" for the following versions:
-    if version in ['138', '138.1', '138.2']:
+    if version in ['138', '138.1', '138.2', '144']:
         tree_url += '.gz'
         tax_url += '.gz'
 

--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -22,14 +22,13 @@ from q2_types.feature_data import RNAFASTAFormat
 def get_silva_data(ctx,
                    version='144',
                    target='SSURef_NR99',
-                   trunc=True,
                    include_species_labels=False,
                    rank_propagation=True,
                    ranks=None,
                    download_sequences=True):
     # download data from SILVA
     print('Downloading raw files may take some time... get some coffee.')
-    queries = _assemble_silva_data_urls(version, target, trunc,
+    queries = _assemble_silva_data_urls(version, target,
                                         download_sequences)
     results = _retrieve_data_from_silva(queries)
     # parse taxonomy
@@ -48,7 +47,7 @@ def get_silva_data(ctx,
     return results['sequences'], taxonomy
 
 
-def _assemble_silva_data_urls(version, target, trunc=True,
+def _assemble_silva_data_urls(version, target,
                               download_sequences=True):
     '''Generate SILVA urls, given database version and reference target.'''
     # assemble target urls
@@ -73,13 +72,8 @@ def _assemble_silva_data_urls(version, target, trunc=True,
     # if we find more inconsistencies.
 
     # construct file urls
-    if trunc:
-        ts = '_trunc'
-    else:
-        ts = ''
-
-    base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva{2}.fasta.gz'.format(
-            version, target, ts)
+    base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva_trunc.fasta.gz'.format(
+            version, target)
 
     # SILVA 144 taxmap file schema has changed to
     # `taxmap_slv_ssu_ref144.txt.gz`

--- a/rescript/parse_silva_taxonomy.py
+++ b/rescript/parse_silva_taxonomy.py
@@ -91,7 +91,18 @@ def _get_clean_organism_name(name):
     return _keep_allowed_chars('_'.join(name.strip().split()[:2]))
 
 
+def get_last_taxmap_taxpath_label(tax_string):
+    return tax_string.strip(';').split(';')[-1]
+
+
 def _prep_taxmap(taxmap):
+    # Check if there are any NaNs in organism_name.
+    # If so, pull last taxonomy item from the taxonomy path and use
+    # that for the organism_name.
+    if taxmap.loc[:, 'organism_name'].isna().any():
+        taxmap.loc[:, 'organism_name'] = taxmap.loc[
+            :, 'organism_name'].fillna(taxmap.loc[:, 'path'].apply(
+                get_last_taxmap_taxpath_label))
     # Return silva taxonomy dataframe map indexed by accession.seqtart.seqstop
     # This is how the coreesponding FASTA file IDs are structured
     taxmap.index = taxmap.index + '.' + taxmap.start + '.' + taxmap.stop

--- a/rescript/parse_silva_taxonomy.py
+++ b/rescript/parse_silva_taxonomy.py
@@ -93,7 +93,7 @@ def _get_clean_organism_name(name):
 
 
 def get_last_taxmap_taxpath_label(tax_string):
-    return tax_string.strip(';').split(';')[-1]
+    return 'unknown_' + tax_string.strip(';').split(';')[-1]
 
 
 def _prep_taxmap(taxmap):

--- a/rescript/parse_silva_taxonomy.py
+++ b/rescript/parse_silva_taxonomy.py
@@ -103,10 +103,6 @@ def _prep_taxmap(taxmap):
     taxmap['organism_name'] = np.where(
         taxmap['organism_name'].isna(), taxmap['path'].apply(
                 get_last_taxmap_taxpath_label), taxmap['organism_name'])
-    # if taxmap.loc[:, 'organism_name'].isna().any():
-    #    taxmap.loc[:, 'organism_name'] = taxmap.loc[
-    #        :, 'organism_name'].fillna(taxmap.loc[:, 'path'].apply(
-    #            get_last_taxmap_taxpath_label))
     # Return silva taxonomy dataframe map indexed by accession.seqtart.seqstop
     # This is how the coreesponding FASTA file IDs are structured
     taxmap.index = taxmap.index + '.' + taxmap.start + '.' + taxmap.stop

--- a/rescript/parse_silva_taxonomy.py
+++ b/rescript/parse_silva_taxonomy.py
@@ -92,7 +92,7 @@ def _get_clean_organism_name(name):
     return _keep_allowed_chars('_'.join(name.strip().split()[:2]))
 
 
-def get_last_taxmap_taxpath_label(tax_string):
+def get_last_taxmap_taxpath_label_add_unknown(tax_string):
     return 'unknown_' + tax_string.strip(';').split(';')[-1]
 
 
@@ -102,7 +102,8 @@ def _prep_taxmap(taxmap):
     # that for the organism_name.
     taxmap['organism_name'] = np.where(
         taxmap['organism_name'].isna(), taxmap['path'].apply(
-                get_last_taxmap_taxpath_label), taxmap['organism_name'])
+            get_last_taxmap_taxpath_label_add_unknown),
+        taxmap['organism_name'])
     # Return silva taxonomy dataframe map indexed by accession.seqtart.seqstop
     # This is how the coreesponding FASTA file IDs are structured
     taxmap.index = taxmap.index + '.' + taxmap.start + '.' + taxmap.stop

--- a/rescript/parse_silva_taxonomy.py
+++ b/rescript/parse_silva_taxonomy.py
@@ -8,6 +8,7 @@
 
 import re
 import pandas as pd
+import numpy as np
 from skbio.tree import TreeNode
 from collections import OrderedDict
 
@@ -99,10 +100,13 @@ def _prep_taxmap(taxmap):
     # Check if there are any NaNs in organism_name.
     # If so, pull last taxonomy item from the taxonomy path and use
     # that for the organism_name.
-    if taxmap.loc[:, 'organism_name'].isna().any():
-        taxmap.loc[:, 'organism_name'] = taxmap.loc[
-            :, 'organism_name'].fillna(taxmap.loc[:, 'path'].apply(
-                get_last_taxmap_taxpath_label))
+    taxmap['organism_name'] = np.where(
+        taxmap['organism_name'].isna(), taxmap['path'].apply(
+                get_last_taxmap_taxpath_label), taxmap['organism_name'])
+    # if taxmap.loc[:, 'organism_name'].isna().any():
+    #    taxmap.loc[:, 'organism_name'] = taxmap.loc[
+    #        :, 'organism_name'].fillna(taxmap.loc[:, 'path'].apply(
+    #            get_last_taxmap_taxpath_label))
     # Return silva taxonomy dataframe map indexed by accession.seqtart.seqstop
     # This is how the coreesponding FASTA file IDs are structured
     taxmap.index = taxmap.index + '.' + taxmap.start + '.' + taxmap.stop

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -695,7 +695,7 @@ version_map, target_map, _ = TypeMap({
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef')): Visualization,
     (Str % Choices('138'),
      Str % Choices('SSURef_NR99', 'SSURef')): Visualization,
-    (Str % Choices('138.1', '138.2'),
+    (Str % Choices('138.1', '138.2', '144'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef_NR99',
                    'LSURef')): Visualization,
 })
@@ -707,6 +707,7 @@ plugin.pipelines.register_function(
     parameters={
         'version': version_map,
         'target': target_map,
+        'trunc': Bool,
         'include_species_labels': Bool,
         'rank_propagation': Bool,
         'ranks': List[Str % Choices(ALLOWED_RANKS)],
@@ -720,6 +721,11 @@ plugin.pipelines.register_function(
                   'small subunit reference. LSURef = redundant large subunit '
                   'reference. SSURef_NR99 = non-redundant (clustered at 99% '
                   'similarity) small subunit reference.',
+        'trunc': 'Sequences in these files haven been truncated. Meaning '
+                 'that all nucleotides that have not been aligned were '
+                 'removed from the sequence. Note, not all database '
+                 'versions contain both a truncated and non-truncated '
+                 'reference sequence file.',
         'include_species_labels': INCLUDE_SPECIES_LABELS_DESCRIPTION,
         'rank_propagation': RANK_PROPAGATE_DESCRIPTION,
         'ranks': RANK_DESCRIPTION,

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -687,7 +687,7 @@ RANK_DESCRIPTION = ('List of taxonomic ranks for building a taxonomy from the '
                     "[default: '" +
                     "', '".join(DEFAULT_RANKS) + "']")
 
-_SILVA_VERSIONS = ['128', '132', '138', '138.1', '138.2']
+_SILVA_VERSIONS = ['128', '132', '138', '138.1', '138.2', '144']
 _SILVA_TARGETS = ['SSURef_NR99', 'SSURef', 'LSURef_NR99', 'LSURef']
 
 version_map, target_map, _ = TypeMap({
@@ -695,9 +695,11 @@ version_map, target_map, _ = TypeMap({
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef')): Visualization,
     (Str % Choices('138'),
      Str % Choices('SSURef_NR99', 'SSURef')): Visualization,
-    (Str % Choices('138.1', '138.2', '144'),
+    (Str % Choices('138.1', '138.2'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef_NR99',
                    'LSURef')): Visualization,
+    (Str % Choices('144'),
+     Str % Choices('SSURef_NR99', 'SSURef')): Visualization,
 })
 
 

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -670,8 +670,9 @@ plugin.methods.register_function(
 
 
 INCLUDE_SPECIES_LABELS_DESCRIPTION = (
-    'Include species rank labels in taxonomy output. Note: species-labels may '
-    'not be reliable in all cases.')
+    'Include \'organism_name\' as the species rank labels in the '
+    'taxonomy output. Note: these \'organism_name\' labels might '
+    'not serve as reliable \'species\' labels in all cases.')
 
 RANK_PROPAGATE_DESCRIPTION = (
     'If a rank has no taxonomy associated with it, the taxonomy from the '

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -690,16 +690,20 @@ RANK_DESCRIPTION = ('List of taxonomic ranks for building a taxonomy from the '
 _SILVA_VERSIONS = ['128', '132', '138', '138.1', '138.2', '144']
 _SILVA_TARGETS = ['SSURef_NR99', 'SSURef', 'LSURef_NR99', 'LSURef']
 
-version_map, target_map, _ = TypeMap({
+version_map, target_map, trunc_map, _ = TypeMap({
     (Str % Choices('128', '132'),
-     Str % Choices('SSURef_NR99', 'SSURef', 'LSURef')): Visualization,
+     Str % Choices('SSURef_NR99', 'SSURef', 'LSURef'),
+     Bool % Choices([True, False])): Visualization,
     (Str % Choices('138'),
-     Str % Choices('SSURef_NR99', 'SSURef')): Visualization,
+     Str % Choices('SSURef_NR99', 'SSURef'),
+     Bool % Choices([True, False])): Visualization,
     (Str % Choices('138.1', '138.2'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef_NR99',
-                   'LSURef')): Visualization,
+                   'LSURef'),
+     Bool % Choices([True, False])): Visualization,
     (Str % Choices('144'),
-     Str % Choices('SSURef_NR99', 'SSURef')): Visualization,
+     Str % Choices('SSURef_NR99', 'SSURef'),
+     Bool % Choices([True])): Visualization,
 })
 
 
@@ -709,7 +713,7 @@ plugin.pipelines.register_function(
     parameters={
         'version': version_map,
         'target': target_map,
-        'trunc': Bool,
+        'trunc': trunc_map,
         'include_species_labels': Bool,
         'rank_propagation': Bool,
         'ranks': List[Str % Choices(ALLOWED_RANKS)],

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -691,20 +691,20 @@ RANK_DESCRIPTION = ('List of taxonomic ranks for building a taxonomy from the '
 _SILVA_VERSIONS = ['128', '132', '138', '138.1', '138.2', '144']
 _SILVA_TARGETS = ['SSURef_NR99', 'SSURef', 'LSURef_NR99', 'LSURef']
 
-version_map, target_map, trunc_map, _ = TypeMap({
+version_map, target_map, _ = TypeMap({
     (Str % Choices('128', '132'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef'),
-     Bool % Choices([True, False])): Visualization,
+     ): Visualization,
     (Str % Choices('138'),
      Str % Choices('SSURef_NR99', 'SSURef'),
-     Bool % Choices([True, False])): Visualization,
+     ): Visualization,
     (Str % Choices('138.1', '138.2'),
      Str % Choices('SSURef_NR99', 'SSURef', 'LSURef_NR99',
                    'LSURef'),
-     Bool % Choices([True, False])): Visualization,
+     ): Visualization,
     (Str % Choices('144'),
      Str % Choices('SSURef_NR99', 'SSURef'),
-     Bool % Choices([True])): Visualization,
+     ): Visualization,
 })
 
 
@@ -714,7 +714,6 @@ plugin.pipelines.register_function(
     parameters={
         'version': version_map,
         'target': target_map,
-        'trunc': trunc_map,
         'include_species_labels': Bool,
         'rank_propagation': Bool,
         'ranks': List[Str % Choices(ALLOWED_RANKS)],
@@ -728,11 +727,6 @@ plugin.pipelines.register_function(
                   'small subunit reference. LSURef = redundant large subunit '
                   'reference. SSURef_NR99 = non-redundant (clustered at 99% '
                   'similarity) small subunit reference.',
-        'trunc': 'Sequences in these files haven been truncated. Meaning '
-                 'that all nucleotides that have not been aligned were '
-                 'removed from the sequence. Note, not all database '
-                 'versions contain both a truncated and non-truncated '
-                 'reference sequence file.',
         'include_species_labels': INCLUDE_SPECIES_LABELS_DESCRIPTION,
         'rank_propagation': RANK_PROPAGATE_DESCRIPTION,
         'ranks': RANK_DESCRIPTION,

--- a/rescript/tests/data/taxmap_144_no_org_name.tsv
+++ b/rescript/tests/data/taxmap_144_no_org_name.tsv
@@ -1,0 +1,5 @@
+primaryAccession	start	stop	path	organism_name	taxid
+AB007908	1	1516	Bacteria;Bacillati;Bacillota;Bacilli;Lactobacillales;Lactobacillaceae;Lactobacillus;	Lactobacillus delbrueckii	59284
+AJ487049	1	1722	Eukaryota;Amorphea;Obazoa;Opisthokonta;Holozoa;Choanozoa;Metazoa;Animalia;BCP clade;Bilateria;Protostomia;Lophotrochozoa;Rotifera;Bdelloidea;Philodinida;	Mniobia russeola	47473
+MZ209196	3	1436	Bacteria;Pseudomonadati;Pseudomonadota;Gammaproteobacteria;Enterobacterales;Enterobacteriaceae;Leclercia-Silvania-Enterobacter--other;		65389
+MZ215963	2	1378	Bacteria;Bacillati;Actinomycetota;Actinomycetes;Actinomycetales--other;Actinomycetaceae--other;Scrofimicrobium;		58063

--- a/rescript/tests/test_parse_silva_taxonomy.py
+++ b/rescript/tests/test_parse_silva_taxonomy.py
@@ -9,15 +9,15 @@
 import qiime2
 import importlib
 from qiime2.plugin.testing import TestPluginBase
-from rescript.parse_silva_taxonomy import (parse_silva_taxonomy,
-                                           _keep_allowed_chars, _prep_taxranks,
-                                           _prep_taxmap, ALLOWED_RANKS,
-                                           DEFAULT_RANKS,
-                                           _build_base_silva_taxonomy,
-                                           _validate_taxrank_taxmap_taxtree,
-                                           _compile_taxonomy_output,
-                                           _get_clean_organism_name,
-                                           _get_terminal_taxon)
+from rescript.parse_silva_taxonomy import (
+                                parse_silva_taxonomy,
+                                _keep_allowed_chars, _prep_taxranks,
+                                _prep_taxmap, ALLOWED_RANKS,
+                                DEFAULT_RANKS, _build_base_silva_taxonomy,
+                                _validate_taxrank_taxmap_taxtree,
+                                _compile_taxonomy_output,
+                                _get_clean_organism_name, _get_terminal_taxon,
+                                get_last_taxmap_taxpath_label_add_unknown)
 from skbio.tree import TreeNode
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
@@ -55,6 +55,10 @@ class TestParseSilvaTaxonomy(TestPluginBase):
             'FeatureData[SILVATaxidMap]',
             self.get_data_path('taxmap_test_match_tree.txt'))
         self.taxmap2 = tm2.view(pd.DataFrame)
+        tm_s144 = qiime2.Artifact.import_data(
+            'FeatureData[SILVATaxidMap]',
+            self.get_data_path('taxmap_144_no_org_name.tsv'))
+        self.taxmap_s144 = tm_s144.view(pd.DataFrame)
         # taxonomy tree file with missing taxid:
         tt2 = qiime2.Artifact.import_data(
             'Phylogeny[Rooted]',
@@ -127,6 +131,30 @@ class TestParseSilvaTaxonomy(TestPluginBase):
                                 'Oryza_sativa'],
               'taxid': ['3698', '45177', '46692', '46463', '2852', '10099',
                         '47183', '4432', '4432', '44317']}
+        exp_taxmap = pd.DataFrame(dm)
+        exp_taxmap.set_index('Feature ID', inplace=True)
+        exp_taxmap.sort_index(inplace=True)
+        assert_frame_equal(obs_taxmap, exp_taxmap)
+
+    def test_get_last_taxmap_taxpath_label_add_unknown(self):
+        ts = ('Bacteria;Bacillati;Actinomycetota;'
+              'Actinomycetes;Actinomycetales--other;'
+              'Actinomycetaceae--other;Scrofimicrobium;')
+        obs_last_label = get_last_taxmap_taxpath_label_add_unknown(ts)
+        exp_last_label = 'unknown_Scrofimicrobium'
+        self.assertEqual(obs_last_label, exp_last_label)
+
+    def test_prep_taxmap_v144_missing_organism_name(self):
+        obs_taxmap = _prep_taxmap(self.taxmap_s144)
+        obs_taxmap.sort_index(inplace=True)
+        dm = {'Feature ID': ['AB007908.1.1516', 'AJ487049.1.1722',
+                             'MZ209196.3.1436', 'MZ215963.2.1378'],
+              'organism_name': [
+                    'Lactobacillus_delbrueckii',
+                    'Mniobia_russeola',
+                    'unknown_Leclercia-Silvania-Enterobacter--other',
+                    'unknown_Scrofimicrobium'],
+              'taxid': ['59284', '47473', '65389', '58063']}
         exp_taxmap = pd.DataFrame(dm)
         exp_taxmap.set_index('Feature ID', inplace=True)
         exp_taxmap.sort_index(inplace=True)


### PR DESCRIPTION
# Description

Fixes #263 

Updates:
- SILVA version 144 does not currently contain LSU reference data. The version and target TypeMap has been updated to reflect this.
- Will now check for missing information in the `organism_name` column of the `taxmap` file. If missing, the last `;` delimited taxonomic label in the `path` column of the `taxmap` file will be extracted. Then that will be used to fill in for the `organism_name`, prefixed with `unknown_`. Thus, the examples in the linked issue above should return:
  - `unknown_Leclercia-Silvania-Enterobacter--other`
  - `unknown_Scrofimicrobium` 
- Will now check for `SSURef` file naming change. SILVA 144 `taxmap` file schema has changed to `taxmap_slv_ssu_ref144.txt.gz`. Prior versions of SILVA have always been in the form of `taxmap_slv_ssu_ref_144.txt.gz`.
- replaces `include_species_labels` with `include_organism_name_labels`
  - I also include this additional and explicit text: " NOT RECOMMENDED FOR GENERAL USE! CONSIDER FOR TESTING PURPOSES ONLY!"

----
EDIT:

~~--p-trunc / --p-no-trunc~~
~~Sequences in these files haven been truncated.~~
~~Meaning that all nucleotides that have not been~~
~~aligned were removed from the sequence. Note, not~~
~~all database versions contain both a truncated and~~
~~non-truncated reference sequence file.~~
~~--p-trunc is now the default. This was added as it appears that SILVA 144 only contains the truncated files, currently.~~
~~--p-trunc` added to TypeMap~~

- ^^Removed `trunc` option. I forgot that the alignment files only exist as `trunc`. Thus, to remain consistent, we should probably only allow the downloading of the unaligned `trunc` files (historically we've not been pulling the `trunc` files). Being consistent will be less confusing for users.
  -  I plan to add the ability to download alignment in a later PR (see issue #265) once this PR is accepted.
----






- [x] add test code for some operations.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.