### PR TITLE
ENH: Allow the ability to download SILVA alignment.

### DIFF
--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -42,19 +42,12 @@ def get_silva_data(ctx,
         ranks=ranks,
         rank_propagation=rank_propagation)
     # if skipping sequences, need to output an empty sequence file.
-    if seq_format == 'None':
-        results['sequences'] = qiime2.Artifact.import_data(
-            'FeatureData[RNASequence]', RNAFASTAFormat())
+    if seq_format == 'Unaligned' or seq_format == 'None':
         results['aligned sequences'] = qiime2.Artifact.import_data(
             'FeatureData[AlignedRNASequence]', AlignedRNAFASTAFormat())
-    if seq_format == 'Unaligned':
-        results['aligned sequences'] = qiime2.Artifact.import_data(
-            'FeatureData[AlignedRNASequence]', AlignedRNAFASTAFormat())
-    if seq_format == 'Aligned':
+    if seq_format == 'Aligned' or seq_format == 'None':
         results['sequences'] = qiime2.Artifact.import_data(
             'FeatureData[RNASequence]', RNAFASTAFormat())
-    # else:
-    #     seq_res = {k: results[k] for k in ['sequences', 'sequences_aligned']}
     return results['sequences'], results['aligned sequences'], taxonomy
 
 

--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -58,7 +58,7 @@ def get_silva_data(ctx,
     return results['sequences'], results['aligned sequences'], taxonomy
 
 
-def _assemble_silva_data_urls(version, target, seq_format): # download_sequences=True
+def _assemble_silva_data_urls(version, target, seq_format):
     '''Generate SILVA urls, given database version and reference target.'''
     # assemble target urls
     ref_map = {'SSURef_NR99': 'ssu_ref_nr',
@@ -85,8 +85,8 @@ def _assemble_silva_data_urls(version, target, seq_format): # download_sequences
     base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva_trunc.fasta.gz'.format(
         version, target)
     base_url_seqs_aln = base_url + \
-         'SILVA_{0}_{1}_tax_silva_full_align_trunc.fasta.gz'.format(
-         version, target)
+        'SILVA_{0}_{1}_tax_silva_full_align_trunc.fasta.gz'.format(
+            version, target)
     base_url_taxmap = '{0}taxonomy/taxmap_slv_{1}_{2}'.format(
         base_url, insert, version)
 
@@ -106,7 +106,8 @@ def _assemble_silva_data_urls(version, target, seq_format): # download_sequences
         tax_url += '.gz'
 
     # download and validate silva files
-    queries = [('aligned sequences', base_url_seqs_aln, 'FeatureData[AlignedRNASequence]'),
+    queries = [('aligned sequences', base_url_seqs_aln,
+                'FeatureData[AlignedRNASequence]'),
                ('sequences', base_url_seqs, 'FeatureData[RNASequence]'),
                ('taxonomy map', base_url_taxmap, 'FeatureData[SILVATaxidMap]'),
                ('taxonomy tree', tree_url, 'Phylogeny[Rooted]'),

--- a/rescript/get_data.py
+++ b/rescript/get_data.py
@@ -16,7 +16,7 @@ import warnings
 import qiime2
 from urllib.request import urlretrieve
 from urllib.error import HTTPError
-from q2_types.feature_data import RNAFASTAFormat
+from q2_types.feature_data import RNAFASTAFormat, AlignedRNAFASTAFormat
 
 
 def get_silva_data(ctx,
@@ -25,10 +25,12 @@ def get_silva_data(ctx,
                    include_species_labels=False,
                    rank_propagation=True,
                    ranks=None,
-                   download_sequences=True):
+                   seq_format='Unaligned',
+                   # download_sequences=True,
+                   ):
     # download data from SILVA
     print('Downloading raw files may take some time... get some coffee.')
-    queries = _assemble_silva_data_urls(version, target, download_sequences)
+    queries = _assemble_silva_data_urls(version, target, seq_format)
     results = _retrieve_data_from_silva(queries)
     # parse taxonomy
     parse_taxonomy = ctx.get_action('rescript', 'parse_silva_taxonomy')
@@ -40,13 +42,23 @@ def get_silva_data(ctx,
         ranks=ranks,
         rank_propagation=rank_propagation)
     # if skipping sequences, need to output an empty sequence file.
-    if not download_sequences:
+    if seq_format == 'None':
         results['sequences'] = qiime2.Artifact.import_data(
             'FeatureData[RNASequence]', RNAFASTAFormat())
-    return results['sequences'], taxonomy
+        results['aligned sequences'] = qiime2.Artifact.import_data(
+            'FeatureData[AlignedRNASequence]', AlignedRNAFASTAFormat())
+    if seq_format == 'Unaligned':
+        results['aligned sequences'] = qiime2.Artifact.import_data(
+            'FeatureData[AlignedRNASequence]', AlignedRNAFASTAFormat())
+    if seq_format == 'Aligned':
+        results['sequences'] = qiime2.Artifact.import_data(
+            'FeatureData[RNASequence]', RNAFASTAFormat())
+    # else:
+    #     seq_res = {k: results[k] for k in ['sequences', 'sequences_aligned']}
+    return results['sequences'], results['aligned sequences'], taxonomy
 
 
-def _assemble_silva_data_urls(version, target, download_sequences=True):
+def _assemble_silva_data_urls(version, target, seq_format): # download_sequences=True
     '''Generate SILVA urls, given database version and reference target.'''
     # assemble target urls
     ref_map = {'SSURef_NR99': 'ssu_ref_nr',
@@ -70,8 +82,11 @@ def _assemble_silva_data_urls(version, target, download_sequences=True):
     # if we find more inconsistencies.
 
     # construct file urls
-    base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva.fasta.gz'.format(
+    base_url_seqs = base_url + 'SILVA_{0}_{1}_tax_silva_trunc.fasta.gz'.format(
         version, target)
+    base_url_seqs_aln = base_url + \
+         'SILVA_{0}_{1}_tax_silva_full_align_trunc.fasta.gz'.format(
+         version, target)
     base_url_taxmap = '{0}taxonomy/taxmap_slv_{1}_{2}'.format(
         base_url, insert, version)
 
@@ -91,14 +106,21 @@ def _assemble_silva_data_urls(version, target, download_sequences=True):
         tax_url += '.gz'
 
     # download and validate silva files
-    queries = [('sequences', base_url_seqs, 'FeatureData[RNASequence]'),
+    queries = [('aligned sequences', base_url_seqs_aln, 'FeatureData[AlignedRNASequence]'),
+               ('sequences', base_url_seqs, 'FeatureData[RNASequence]'),
                ('taxonomy map', base_url_taxmap, 'FeatureData[SILVATaxidMap]'),
                ('taxonomy tree', tree_url, 'Phylogeny[Rooted]'),
                ('taxonomy ranks', tax_url, 'FeatureData[SILVATaxonomy]')]
 
     # optionally skip downloading sequences
-    if not download_sequences:
+    if seq_format == 'None':
+        queries = queries[2:]
+    if seq_format == 'Unaligned':
         queries = queries[1:]
+    if seq_format == 'Aligned':
+        queries = [queries[0]] + queries[2:]
+    # if not download_sequences:
+    #     queries = queries[1:]
 
     return queries
 

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -711,7 +711,6 @@ plugin.pipelines.register_function(
         'rank_propagation': Bool,
         'ranks': List[Str % Choices(ALLOWED_RANKS)],
         'seq_format': Str % Choices(['Aligned', 'Unaligned', 'Both', 'None'])
-        #'download_sequences': Bool
         },
     outputs=[('silva_sequences', FeatureData[RNASequence]),
              ('silva_sequences_aligned', FeatureData[AlignedRNASequence]),
@@ -729,7 +728,7 @@ plugin.pipelines.register_function(
         'seq_format': 'Select the format of sequence data to be downlaoded. '
                       'Choose \'Both\' to download the aligned and unaliged '
                       'sequenced data. Choose \'None\' if no sequence data '
-                      'should be downlaoded',
+                      'should be downlaoded.',
                               },
     output_descriptions={
         'silva_sequences': 'SILVA reference sequences.',

--- a/rescript/plugin_setup.py
+++ b/rescript/plugin_setup.py
@@ -710,8 +710,11 @@ plugin.pipelines.register_function(
         'include_species_labels': Bool,
         'rank_propagation': Bool,
         'ranks': List[Str % Choices(ALLOWED_RANKS)],
-        'download_sequences': Bool},
+        'seq_format': Str % Choices(['Aligned', 'Unaligned', 'Both', 'None'])
+        #'download_sequences': Bool
+        },
     outputs=[('silva_sequences', FeatureData[RNASequence]),
+             ('silva_sequences_aligned', FeatureData[AlignedRNASequence]),
              ('silva_taxonomy', FeatureData[Taxonomy])],
     input_descriptions={},
     parameter_descriptions={
@@ -723,17 +726,14 @@ plugin.pipelines.register_function(
         'include_species_labels': INCLUDE_SPECIES_LABELS_DESCRIPTION,
         'rank_propagation': RANK_PROPAGATE_DESCRIPTION,
         'ranks': RANK_DESCRIPTION,
-        'download_sequences': 'Toggle whether or not to download and import '
-                              'the SILVA reference sequences associated with '
-                              'the release. Skipping the sequences is useful '
-                              'if you only want to download and parse the '
-                              'taxonomy, e.g., a local copy of the sequences '
-                              'already exists or for testing purposes. NOTE: '
-                              'if this option is used, a `silva_sequences` '
-                              'output is still created, but contains no '
-                              'data.'},
+        'seq_format': 'Select the format of sequence data to be downlaoded. '
+                      'Choose \'Both\' to download the aligned and unaliged '
+                      'sequenced data. Choose \'None\' if no sequence data '
+                      'should be downlaoded',
+                              },
     output_descriptions={
         'silva_sequences': 'SILVA reference sequences.',
+        'silva_sequences_aligned': 'SILVA reference sequences, aligned.',
         'silva_taxonomy': 'SILVA reference taxonomy.'},
     name='Download, parse, and import SILVA database.',
     description=(


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
Addresses #265. 
Added the flag `--p-seq-format`. This will allow the user to download :
- `Aligned` sequence data
- `Unaligned` sequence data
- `Both` the aligned and unaligned sequence data
- `None` of the sequence data, just the taxonomy

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [x] NO AI USED.
- [ ] AI USED.


# AI Usage Details
<!-- REQUIRED if 'AI USED' is checked. This section can be deleted if 'NO AI USED' is checked. -->
